### PR TITLE
chore: bump to nightly-2021-10-18

### DIFF
--- a/Mathport/Syntax/Translate/Tactic/Mathlib.lean
+++ b/Mathport/Syntax/Translate/Tactic/Mathlib.lean
@@ -965,7 +965,7 @@ def trSuggestUsing (args : Array BinderName) : M Syntax := do
 @[trTactic norm_num] def trNormNum : TacM Syntax := do
   let hs := trSimpList (← trSimpArgs (← parse simpArgList))
   let loc := mkOptionalNode $ ← trLoc (← parse location)
-  mkNode ``Parser.Tactic.normNum #[mkAtom "normNum", hs, loc]
+  mkNode ``Lean.tacticNormNum #[mkAtom "normNum", hs, loc]
 
 @[trTactic apply_normed] def trApplyNormed : TacM Syntax := do
   `(tactic| applyNormed $(← trExpr (← parse pExpr)))

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -9,7 +9,7 @@ package mathport {
     -- as changes to tactics in mathlib4 often cause breakages here,
     -- particularly in `Mathport/Syntax/Translate/Tactic/Mathlib.lean`.
     -- We'll need to keep updating that file, and bumping the commit here.
-    src := Source.git "https://github.com/leanprover-community/mathlib4.git" "b28a3d51e722d8b43367035e0eb5790b4cb6da53",
+    src := Source.git "https://github.com/leanprover-community/mathlib4.git" "fad6b41b420d25d84e43c044e4433d6dced42a61",
     dir := FilePath.mk "."
   }],
   binRoot := `MathportApp

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2021-10-16
+leanprover/lean4:nightly-2021-10-18


### PR DESCRIPTION
Gabriel changed how the `normNum` tactic was set up in https://github.com/leanprover-community/mathlib4/commit/6b8b2390f3a404c446e9d9d80ea20fa67448d2a4, necessitating an update in `Mathport/Syntax/Translate/Tactic/Mathlib.lean`.