### PR TITLE
chore: bump mathlib4 and lean

### DIFF
--- a/Mathport/Syntax/Translate/Basic.lean
+++ b/Mathport/Syntax/Translate/Basic.lean
@@ -8,6 +8,7 @@ import Mathport.Syntax.Data4
 import Mathport.Syntax.Translate.Notation
 import Mathport.Syntax.Translate.Attributes
 import Mathport.Syntax.Translate.Parser
+import Mathlib
 
 namespace Mathport
 
@@ -637,7 +638,7 @@ def trExpr' : Expr → M Syntax
   | Expr.«`()» _ true e => do `(quote $(← trExpr e.kind))
   | Expr.«`()» false false e => do `(pquote $(← trExpr e.kind))
   | Expr.«`()» true false e => do `(ppquote $(← trExpr e.kind))
-  | Expr.«%%» e => do `(%%$(← trExpr e.kind))
+  | Expr.«%%» e => do `(%%ₓ$(← trExpr e.kind))
   | Expr.«`[]» tacs => do
     dbg_trace "warning: unsupported (TODO): `[tacs]"
     `(sorry)
@@ -664,8 +665,9 @@ def trExpr' : Expr → M Syntax
   | Expr.«{,}» es => do `({$(← es.mapM fun e => trExpr e.kind),*})
   | Expr.subtype false x ty p => do
     `({$(mkIdent x.kind) $[: $(← ty.mapM fun e => trExpr e.kind)]? // $(← trExpr p.kind)})
-  | Expr.subtype true x ty p => do
-    `({$(mkIdent x.kind) $[: $(← ty.mapM fun e => trExpr e.kind)]? | $(← trExpr p.kind)})
+  | Expr.subtype true x none p => do `({$(mkIdent x.kind) | $(← trExpr p.kind)})
+  | Expr.subtype true x (some ty) p => do
+    `({$(mkIdent x.kind) : $(← trExpr ty.kind) | $(← trExpr p.kind)})
   | Expr.sep x ty p => do
     `({$(mkIdent x.kind) ∈ $(← trExpr ty.kind) | $(← trExpr p.kind)})
   | Expr.setReplacement e bis => do

--- a/Mathport/Syntax/Translate/Tactic/Lean3.lean
+++ b/Mathport/Syntax/Translate/Tactic/Lean3.lean
@@ -229,10 +229,8 @@ where
   let h := mkOptionalNode' h fun h => #[mkIdent h, mkNullNode]
   let ty := mkOptionalNode $ ← trOptType (← parse (tk ":" *> pExpr)?)
   match ← parse (tk ":=" *> pExpr)? with
-  | some pr =>
-    let haveId := mkNode ``Parser.Term.haveIdDecl #[h, ty, mkAtom ":=", ← trExpr pr]
-    `(tactic| have $haveId:haveIdDecl)
-  | none => mkNode ``Parser.Tactic.have'' #[mkAtom "have", h, ty]
+  | some pr => `(tactic| have $h:ident : $ty:term := $(← trExpr pr))
+  | none => `(tactic| have $h:ident : $ty:term)
 
 @[trTactic «let»] def trLet : TacM Syntax := do
   let h ← parse (ident)?

--- a/Mathport/Util/Misc.lean
+++ b/Mathport/Util/Misc.lean
@@ -6,6 +6,7 @@ Authors: Mario Carneiro, Daniel Selsam
 import Lean
 import Std.Data.HashMap
 import Std.Data.RBMap
+import Mathlib.Tactic.Lint
 
 def uncurry (f : α → β → γ) : α × β → γ
   | (x, y) => f x y
@@ -90,11 +91,6 @@ def Subarray.getOp {α : Type u} [Inhabited α] (self : Subarray α) (idx : Nat)
   if prec >= p then paren f else f
 
 instance : Coe (Array α) (Subarray α) := ⟨(·[0:])⟩
-
-def Option.mapM {α : Type u} {β : Type v} {m : Type v → Type w} [Monad m] (f : α → m β) :
-    Option α → m (Option β)
-  | none => pure none
-  | some a => some <$> f a
 
 /-- Run action with `stdin` emptied and `stdout+stderr` captured into a `String`. -/
 def IO.FS.withIsolatedStreams' [Monad m] [MonadFinally m] [MonadLiftT IO m] (x : m α) : m (String × α) := do

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -9,7 +9,7 @@ package mathport {
     -- as changes to tactics in mathlib4 may cause breakages here.
     -- Please ensure that `lean-toolchain` points to the same release of Lean 4
     -- as this commit of mathlib4 uses.
-    src := Source.git "https://github.com/leanprover-community/mathlib4.git" "9b812ac66f32a5b4f016329c6537f775a8ed4ff6"
+    src := Source.git "https://github.com/leanprover-community/mathlib4.git" "75b0024c6e720126877e415c744bbe1f01e841e5"
   }],
   binRoot := `MathportApp
   moreLinkArgs := if Platform.isWindows then #[] else #["-rdynamic"]


### PR DESCRIPTION
The only significant "regression" is that options to the `#lint` command are no longer translated.  I've already couldn't figure out how to match on the syntax to write an elaborator in mathlib, and I don't think it's easier to construct the syntax here.  Luckily the `#lint` command is used zero times in mathlib so this shouldn't be a huge issue.

Companion PR to https://github.com/leanprover-community/mathlib4/pull/102