### PR TITLE
feat: translate Lean3 split tactic to Lean 4 constructor

### DIFF
--- a/Mathport/Syntax/Translate/Tactic/Lean3.lean
+++ b/Mathport/Syntax/Translate/Tactic/Lean3.lean
@@ -265,7 +265,7 @@ where
 
 @[trTactic right] def trRight : TacM Syntax := `(tactic| right)
 
-@[trTactic split] def trSplit : TacM Syntax := `(tactic| split)
+@[trTactic split] def trSplit : TacM Syntax := `(tactic| constructor)
 
 @[trTactic constructor_matching] def trConstructorM : TacM Syntax := do
   let _rec ← parse (tk "*")?

--- a/Mathport/Syntax/Translate/Tactic/Mathlib.lean
+++ b/Mathport/Syntax/Translate/Tactic/Mathlib.lean
@@ -208,7 +208,7 @@ partial def trRIntroPat : RIntroPat → M Syntax
 @[trNITactic tactic.exact_dec_trivial] def trExactDecTrivial (_ : AST3.Expr) : M Syntax :=
   `(tactic| decide)
 
-@[trTactic fsplit] def trFSplit : TacM Syntax := `(tactic| fsplit)
+@[trTactic fsplit] def trFSplit : TacM Syntax := `(tactic| fconstructor)
 
 @[trTactic injections_and_clear] def trInjectionsAndClear : TacM Syntax :=
   `(tactic| injectionsAndClear)


### PR DESCRIPTION
Lean 4 now uses `split` as a souped-up version of `split_ifs`. It seems likely that we can replace all calls to `split` in Lean3/mathlib3 with `constructor` (which is in principle more powerful: it tries all constructors).

https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Renaming.20.60split.60

If we're concerned about this breaking something it alternatively shouldn't be too hard to backport replacing `split` with `constructors` in mathlib3.