### PR TITLE
fix: fall back to reprinter

### DIFF
--- a/Mathport/Syntax/Translate/Basic.lean
+++ b/Mathport/Syntax/Translate/Basic.lean
@@ -572,7 +572,7 @@ def trNotation (n : Choice) (args : Array (Spanned Arg)) : M Syntax := do
   | Choice.one n => n
   | Choice.many ns =>
     if ns[1:].all (ns[0] == ·) then ns[0] else
-      warn! "unsupported: ambiguous notation"
+      warn! "unsupported: ambiguous notation" | ns[0]
   match ← getNotationEntry? n.getString!, args.map (·.kind) with
   | some ⟨_, _, NotationKind.const stx, _⟩, #[] => stx
   | some ⟨_, _, NotationKind.const stx, _⟩, _ => warn! "unsupported (impossible)"
@@ -606,7 +606,7 @@ def trInfixFn (n : Choice) (e : Option (Spanned Expr)) : M Syntax := do
   | Choice.one n => n
   | Choice.many ns =>
     if ns[1:].all (ns[0] == ·) then ns[0] else
-      warn! "unsupported: ambiguous notation"
+      warn! "unsupported: ambiguous notation" | ns[0]
   trBinary n mkCDot $ ← match e with
   | none => mkCDot
   | some e => trExpr e.kind

--- a/Mathport/Syntax/Translate/Tactic/Lean3.lean
+++ b/Mathport/Syntax/Translate/Tactic/Lean3.lean
@@ -15,7 +15,7 @@ def trLoc (loc : Location) : M (Option Syntax) := do
   let loc : Option Syntax ← match loc with
     | Location.wildcard =>
       some $ mkNode ``Parser.Tactic.locationWildcard #[mkAtom "*"]
-    | Location.targets #[] false => throw! "unsupported"
+    | Location.targets #[] false => warn! "unsupported"
     | Location.targets #[] true => none
     | Location.targets hs goal =>
       some $ mkNode ``Parser.Tactic.locationHyp #[
@@ -96,7 +96,7 @@ def trRwArgs : TacM (Array Syntax × Option Syntax) := do
   let q ← liftM $ (← parse rwRules).mapM trRwRule
   let loc ← trLoc (← parse location)
   if let some cfg ← expr? then
-    dbg_trace "warning: unsupported: rw with cfg"
+    warn! "warning: unsupported: rw with cfg: {repr cfg}"
   (q, loc)
 
 @[trTactic rewrite rw] def trRw : TacM Syntax := do
@@ -218,8 +218,8 @@ where
     let ty ← trDArrow bis ty.kind
     vars.foldlM (init := out) fun out v => do
       out.push $ ← `(($(trBinderName v.kind) : $ty))
-  | Binder.collection _ _ _ _, out => throw! "unsupported: assume with binder collection"
-  | Binder.notation _, out => throw! "unsupported: assume notation"
+  | Binder.collection _ _ _ _, out => warn! "unsupported: assume with binder collection"
+  | Binder.notation _, out => warn! "unsupported: assume notation"
 
   trIntroBinders (bis : Array (Spanned Binder)) : M (Array Syntax) := do
     bis.foldlM (fun out bi => trIntroBinder bi.kind out) #[]
@@ -365,9 +365,9 @@ def trSimpAttrs (attrs : Array Name) : Syntax :=
 
 @[trTactic simp] def trSimp : TacM Syntax := do
   let iota ← parse (tk "!")?
-  if iota.isSome then dbg_trace "warning: unsupported simp config option: iota_eqn"
+  if iota.isSome then warn! "warning: unsupported simp config option: iota_eqn"
   let trace ← parse (tk "?")?
-  if trace.isSome then dbg_trace "warning: unsupported simp config option: trace_lemmas"
+  if trace.isSome then warn! "warning: unsupported simp config option: trace_lemmas"
   let o := if ← parse onlyFlag then mkNullNode #[mkAtom "only"] else mkNullNode
   let (hs, all) ← filterSimpStar (← trSimpArgs (← parse simpArgList))
   let hs := trSimpList hs
@@ -388,7 +388,7 @@ def trSimpAttrs (attrs : Array Name) : Syntax :=
   let o ← parse onlyFlag
   let hs ← parse simpArgList
   let attrs ← parse withIdentList
-  throw! "unsupported: trace_simp_set"
+  warn! "unsupported: trace_simp_set"
 
 @[trTactic simp_intros] def trSimpIntros : TacM Syntax := do
   let ids ← parse ident_*
@@ -424,7 +424,7 @@ def trSimpAttrs (attrs : Array Name) : Syntax :=
 @[trTactic subst] def trSubst : TacM Syntax := do
   let n ← match (← parse pExpr).unparen with
   | AST3.Expr.ident n => n
-  | _ => throw! "unsupported"
+  | _ => warn! "unsupported"
   `(tactic| subst $(mkIdent n):ident)
 
 @[trTactic subst_vars] def trSubstVars : TacM Syntax := `(tactic| substVars)
@@ -486,7 +486,7 @@ def trSimpAttrs (attrs : Array Name) : Syntax :=
 @[trTactic match_target] def trMatchTarget : TacM Syntax := do
   let t ← trExpr (← parse pExpr)
   let m ← expr?
-  if m.isSome then dbg_trace "warning: unsupported: match_target reducibility"
+  if m.isSome then warn! "warning: unsupported: match_target reducibility"
   `(tactic| matchTarget $t)
 
 @[trTactic by_cases] def trByCases : TacM Syntax := do
@@ -512,9 +512,8 @@ def trSimpAttrs (attrs : Array Name) : Syntax :=
     match e.unparen with
     | Expr.ident h => h
     | Expr.«@» false ⟨_, Expr.ident h⟩ =>
-      dbg_trace "unsupported: specialize @hyp"
-      h
-    | _ => throw! "unsupported: specialize non-hyp"
+      warn! "unsupported: specialize @hyp" | h
+    | _ => warn! "unsupported: specialize non-hyp"
   `(tactic| specialize $(Syntax.mkApp (mkIdent head) args))
 
 @[trTactic congr] def trCongr : TacM Syntax := do `(tactic| congr)
@@ -582,7 +581,7 @@ def trSimpAttrs (attrs : Array Name) : Syntax :=
 @[trConv rewrite rw] def trRwConv : TacM Syntax := do
   let q ← liftM $ (← parse rwRules).mapM trRwRule
   if let some cfg ← expr? then
-    dbg_trace "warning: unsupported: rw with cfg"
+    warn! "warning: unsupported: rw with cfg"
   `(conv| rw [$q,*])
 
 section
@@ -617,8 +616,8 @@ private partial def getStr : AST3.Expr → M String
   | Expr.notation n #[⟨_, Arg.expr s1⟩, ⟨_, Arg.expr s2⟩] => do
     if n.name == `«expr ++ » then
       pure $ (← getStr s1.unparen) ++ (← getStr s2.unparen)
-    else throw! "unsupported"
-  | _ => throw! "unsupported"
+    else warn! "unsupported"
+  | _ => warn! "unsupported"
 
 def trInterpolatedStr (f : Syntax → TacM Syntax := pure) : TacM Syntax := do
   let s ← getStr (← expr!).unparen

--- a/Mathport/Syntax/Translate/Tactic/Lean3.lean
+++ b/Mathport/Syntax/Translate/Tactic/Lean3.lean
@@ -424,7 +424,7 @@ def trSimpAttrs (attrs : Array Name) : Syntax :=
 @[trTactic subst] def trSubst : TacM Syntax := do
   let n ← match (← parse pExpr).unparen with
   | AST3.Expr.ident n => n
-  | _ => warn! "unsupported"
+  | _ => warn! "unsupported: subst (term)"
   `(tactic| subst $(mkIdent n):ident)
 
 @[trTactic subst_vars] def trSubstVars : TacM Syntax := `(tactic| substVars)
@@ -581,7 +581,7 @@ def trSimpAttrs (attrs : Array Name) : Syntax :=
 @[trConv rewrite rw] def trRwConv : TacM Syntax := do
   let q ← liftM $ (← parse rwRules).mapM trRwRule
   if let some cfg ← expr? then
-    warn! "warning: unsupported: rw with cfg"
+    warn! "warning: unsupported: rw with cfg: {repr cfg}"
   `(conv| rw [$q,*])
 
 section
@@ -616,8 +616,8 @@ private partial def getStr : AST3.Expr → M String
   | Expr.notation n #[⟨_, Arg.expr s1⟩, ⟨_, Arg.expr s2⟩] => do
     if n.name == `«expr ++ » then
       pure $ (← getStr s1.unparen) ++ (← getStr s2.unparen)
-    else warn! "unsupported"
-  | _ => warn! "unsupported"
+    else warn! "unsupported: interpolated non string literal"
+  | _ => warn! "unsupported: interpolated non string literal"
 
 def trInterpolatedStr (f : Syntax → TacM Syntax := pure) : TacM Syntax := do
   let s ← getStr (← expr!).unparen

--- a/Mathport/Syntax/Translate/Tactic/Mathlib.lean
+++ b/Mathport/Syntax/Translate/Tactic/Mathlib.lean
@@ -93,7 +93,7 @@ def trWithIdentList : Array BinderName → Option (Array Syntax)
   `(command| copy_doc_string $(← mkIdentI fr) → $(← liftM $ to_.mapM mkIdentI)*)
 
 @[trUserCmd «library_note»] def trLibraryNote (doc : Option String) : TacM Syntax := do
-  let Expr.string s ← parse pExpr | throw! "unsupported: weird string"
+  let Expr.string s ← parse pExpr | warn! "unsupported: weird string"
   `(command| $(trDocComment doc.get!):docComment library_note $(Syntax.mkStrLit s))
 
 @[trUserCmd «add_tactic_doc»] def trAddTacticDoc (doc : Option String) : TacM Syntax := do
@@ -214,7 +214,7 @@ partial def trRIntroPat : RIntroPat → M Syntax
   `(tactic| injectionsAndClear)
 
 @[trUserCmd «run_parser»] def trRunParser : TacM Syntax := do
-  throw! "unsupported: run_parser" -- unattested
+  warn! "unsupported: run_parser" -- unattested
 
 @[trNITactic tactic.classical] def trNIClassical (_ : AST3.Expr) : M Syntax :=
   `(tactic| classical)
@@ -248,7 +248,7 @@ def trInterpolatedStr' := trInterpolatedStr fun stx => `(← $stx)
   let d ← match d.unparen with
   | AST3.Expr.ident `none => pure $ none
   | AST3.Expr.string s => pure $ some (Syntax.mkStrLit s)
-  | _ => throw! "unsupported: weird string"
+  | _ => warn! "unsupported: weird string"
   `(command| mk_simp_attribute $(mkIdent n) $[from $(withList.map (·.map mkIdent))*]? $[:= $d]?)
 
 -- # tactic.interactive
@@ -283,13 +283,13 @@ def trInterpolatedStr' := trInterpolatedStr fun stx => `(← $stx)
 @[trTactic swap] def trSwap : TacM Syntax := do
   let e ← (← expr?).mapM fun
   | AST3.Expr.nat n => Quote.quote n
-  | _ => throw! "unsupported: weird nat"
+  | _ => warn! "unsupported: weird nat"
   `(tactic| swap $(e)?)
 
 @[trTactic rotate] def trRotate : TacM Syntax := do
   let e ← (← expr?).mapM fun
   | AST3.Expr.nat n => Quote.quote n
-  | _ => throw! "unsupported: weird nat"
+  | _ => warn! "unsupported: weird nat"
   `(tactic| rotate $(e)?)
 
 @[trTactic clear_] def trClear_ : TacM Syntax := `(tactic| clear_)
@@ -344,7 +344,7 @@ def trInterpolatedStr' := trInterpolatedStr fun stx => `(← $stx)
 @[trTactic guard_hyp_nums] def trGuardHypNums : TacM Syntax := do
   match (← expr!).unparen with
   | AST3.Expr.nat n => `(tactic| guardHypNums $(Quote.quote n))
-  | _ => throw! "unsupported: weird nat"
+  | _ => warn! "unsupported: weird nat"
 
 @[trTactic guard_tags] def trGuardTags : TacM Syntax := do
   `(tactic| guardTags $((← parse ident*).map mkIdent)*)
@@ -356,7 +356,7 @@ def trInterpolatedStr' := trInterpolatedStr fun stx => `(← $stx)
   let t ← trBlock (← itactic)
   match (← expr!).unparen with
   | AST3.Expr.string s => `(tactic| failIfSuccess? $(Syntax.mkStrLit s) $t:tacticSeq)
-  | _ => throw! "unsupported: weird string"
+  | _ => warn! "unsupported: weird string"
 
 @[trTactic field] def trField : TacM Syntax := do
   `(tactic| field $(mkIdent (← parse ident)) => $(← trBlock (← itactic)):tacticSeq)
@@ -369,7 +369,7 @@ def trInterpolatedStr' := trInterpolatedStr fun stx => `(← $stx)
   let hs ← liftM $ (← parse pExprListOrTExpr).mapM trExpr
   let n ← (← expr?).mapM fun
   | AST3.Expr.nat n => Quote.quote n
-  | _ => throw! "unsupported: weird nat"
+  | _ => warn! "unsupported: weird nat"
   let cfg ← liftM $ (← expr?).mapM trExpr
   `(tactic| applyRules $[(config := $cfg)]? [$hs,*] $(n)?)
 
@@ -446,7 +446,7 @@ attribute [trTactic subst'] trSubst
 @[trTactic apply_assumption] def trApplyAssumption : TacM Syntax := do
   match ← expr?, ← expr?, ← expr? with
   | none, none, none => `(tactic| applyAssumption)
-  | _, _, _ => throw! "unsupported: apply_assumption arguments" -- unattested
+  | _, _, _ => warn! "unsupported: apply_assumption arguments" -- unattested
 
 @[trTactic solve_by_elim] def trSolveByElim : TacM Syntax := do
   let star := mkOptionalNode $ (← parse (tk "*")?).map fun _ => mkAtom "*"
@@ -464,7 +464,7 @@ attribute [trTactic subst'] trSubst
 @[trUserCmd «add_hint_tactic»] def trAddHintTactic : TacM Syntax := do
   let tac ← match (← parse $ pExpr *> withInput pExpr).1 with
   | Expr.«`[]» tacs => trIdTactic ⟨false, none, none, tacs⟩
-  | _ => throw! "unsupported (impossible)"
+  | _ => warn! "unsupported (impossible)"
   `(command| add_hint_tactic $tac)
 
 @[trTactic hint] def trHint : TacM Syntax := `(tactic| hint)
@@ -504,10 +504,10 @@ attribute [trTactic clear'] trClear
 -- # tactic.converter
 
 @[trTactic old_conv] def trOldConv : TacM Syntax := do
-  throw! "unsupported tactic old_conv" -- unattested
+  warn! "unsupported tactic old_conv" -- unattested
 
 @[trTactic find] def trFindTac : TacM Syntax := do
-  throw! "unsupported tactic find" -- unattested
+  warn! "unsupported tactic find" -- unattested
 
 @[trTactic conv_lhs] def trConvLHS : TacM Syntax := do
   `(tactic| convLHS
@@ -524,7 +524,7 @@ attribute [trTactic clear'] trClear
 @[trConv erw] def trERwConv : TacM Syntax := do
   let q ← liftM $ (← parse rwRules).mapM trRwRule
   if let some cfg ← expr? then
-    dbg_trace "warning: unsupported: erw with cfg"
+    warn! "warning: unsupported: erw with cfg: {repr cfg}"
   `(conv| erw [$q,*])
 
 @[trConv apply_congr] def trApplyCongr : TacM Syntax := do
@@ -649,13 +649,13 @@ def trUsingList (args : Array AST3.Expr) : M Syntax :=
 
 @[trUserCmd «localized»] def trLocalized : TacM Unit := do
   let (#[cmd], loc) ← parse $ do (← pExpr *> emittedCodeHere, ← tk "in" *> ident)
-    | throw! "unsupported: multiple localized"
+    | warn! "unsupported: multiple localized"
   let loc ← mkIdentN loc
   let pushL stx := pushM `(command| localized [$loc] $stx)
   let cmd ← match cmd with
   | Command.attribute true mods attrs ns => trAttributeCmd false attrs ns pushL
   | Command.notation (true, res) attrs n => trNotationCmd (false, res) attrs n pushL
-  | _ => throw! "unsupported: unusual localized"
+  | _ => warn! "unsupported: unusual localized"
 
 -- # tactic.mk_iff_of_inductive_prop
 @[trUserCmd «mk_iff_of_inductive_prop»] def trMkIffOfInductiveProp : TacM Syntax := do
@@ -673,7 +673,7 @@ def trUsingList (args : Array AST3.Expr) : M Syntax :=
   | some `move => `(attr| normCast move)
   | some `squash => `(attr| normCast squash)
   | none => `(attr| normCast)
-  | _ => throw! "unsupported (impossible)"
+  | _ => warn! "unsupported (impossible)"
 
 @[trTactic push_cast] def trPushCast : TacM Syntax := do
   let hs := trSimpList (← trSimpArgs (← parse simpArgList))
@@ -895,7 +895,7 @@ def trSimpsRule : Sum (Name × Name) Name × Bool → M Syntax
 def trSuggestUsing (args : Array BinderName) : M Syntax := do
   let args ← args.mapM fun
   | BinderName.ident n => mkIdent n
-  | BinderName._ => throw! "unsupported: using _ in suggest/library_search"
+  | BinderName._ => warn! "unsupported: using _ in suggest/library_search"
   mkNullNode $ ← match args with
   | #[] => #[]
   | _ => do #[mkAtom "using", mkNullNode args]
@@ -933,7 +933,7 @@ def trSuggestUsing (args : Array BinderName) : M Syntax := do
 
 -- # tactic.unify_equations
 @[trTactic unify_equations] def trUnifyEquations : TacM Syntax := do
-  throw! "unsupported tactic unify_equations" -- unattested
+  warn! "unsupported tactic unify_equations" -- unattested
 
 -- # tactic.where
 @[trUserCmd «#where»] def trWhereCmd : TacM Syntax := parse skipAll *> `(command| #where)
@@ -969,7 +969,7 @@ def trSuggestUsing (args : Array BinderName) : M Syntax := do
   | some _, none, loc => `(tactic| abel! $(loc)?)
   | some _, some `raw, loc => `(tactic| abel! raw $(loc)?)
   | some _, some `term, loc => `(tactic| abel! term $(loc)?)
-  | _, _, _ => throw! "bad abel mode"
+  | _, _, _ => warn! "bad abel mode"
 
 -- # tactic.ring
 @[trTactic ring1] def trRing1 : TacM Syntax := do
@@ -980,7 +980,7 @@ def trSuggestUsing (args : Array BinderName) : M Syntax := do
 def trRingMode (n : Name) : M Syntax :=
   if [`SOP, `raw, `horner].contains n then
     mkNode ``Parser.Tactic.ringMode #[mkIdent n]
-  else throw! "bad ring mode"
+  else warn! "bad ring mode"
 
 @[trTactic ring_nf] def trRingNF : TacM Syntax := do
   let c ← parse (tk "!")?
@@ -1078,7 +1078,7 @@ def trRingMode (n : Name) : M Syntax :=
   | some `right => `(attr| mono right)
   | some `both => `(attr| mono)
   | none => `(attr| mono)
-  | _ => throw! "unsupported (impossible)"
+  | _ => warn! "unsupported (impossible)"
 
 @[trTactic mono] def trMono : TacM Syntax := do
   let star := mkOptionalNode' (← parse (tk "*")?) fun _ => #[mkAtom "*"]
@@ -1087,7 +1087,7 @@ def trRingMode (n : Name) : M Syntax :=
   | some `right => some (mkAtom "right")
   | some `both => none
   | none => none
-  | _ => throw! "unsupported (impossible)"
+  | _ => warn! "unsupported (impossible)"
   let w ← match ← parse ((tk "with" *> pExprListOrTExpr) <|> pure #[]) with
   | #[] => none
   | w => liftM $ some <$> w.mapM trExpr
@@ -1148,8 +1148,8 @@ def trRingMode (n : Name) : M Syntax :=
 -- # tactic.slice
 
 @[trConv slice] def trSliceConv : TacM Syntax := do
-  let AST3.Expr.nat a ← expr! | throw! "slice: weird nat"
-  let AST3.Expr.nat b ← expr! | throw! "slice: weird nat"
+  let AST3.Expr.nat a ← expr! | warn! "slice: weird nat"
+  let AST3.Expr.nat b ← expr! | warn! "slice: weird nat"
   `(conv| slice $(Quote.quote a) $(Quote.quote b))
 
 @[trTactic slice_lhs] def trSliceLHS : TacM Syntax := do
@@ -1304,7 +1304,7 @@ attribute [trNITactic try_refl_tac] trControlLawsTac
   let tgt ← liftM $ tgt.mapM mkIdentI
   let doc ← doc.mapM fun doc => match doc.unparen with
   | Expr.string s => Syntax.mkStrLit s
-  | _ => throw! "to_additive: weird doc string"
+  | _ => warn! "to_additive: weird doc string"
   match bang, ques with
   | none, none => `(attr| toAdditive $(tgt)? $(doc)?)
   | some _, none => `(attr| toAdditive! $(tgt)? $(doc)?)
@@ -1315,7 +1315,7 @@ attribute [trNITactic try_refl_tac] trControlLawsTac
 @[trUserAttr monotonicity] def trMonotonicityAttr := tagAttr `monotonicity
 
 @[trUserCmd «coinductive»] def trCoinductivePredicate (mods : Modifiers) : TacM Syntax := do
-  parse () *> throw! "unsupported user cmd coinductive" -- unattested
+  parse () *> warn! "unsupported user cmd coinductive" -- unattested
 
 -- # testing.slim_check.sampleable
 @[trUserCmd «#sample»] def trSampleCmd : TacM Syntax := do


### PR DESCRIPTION
Produce clearer output when the parenthesizer fails.  Instead of the Lean 3 version (which I always mistook for Lean 4 code), it now outputs a best-effort reprinted version of the syntax tree:
```lean
-- failed to parenthesize: parenthesize: uncaught backtrack exception
-- failed to format: format: uncaught backtrack exception
protected
  theorem
    add_left_cancel
    : ∀ { n m k : ℕ } , n + m = n + k → m = k
    | 0 , m , k => by simp ( config := { contextual := Bool.true._@._internal._hyg.0 } ) [ Nat.zero_add ]
      | succ n , m , k => fun h => have : n + m = n + k := by simp [ succ_add ] at h assumption add_left_cancel this
```