### PR TITLE
clean up before and after build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,12 @@ jobs:
     name: Build
     runs-on: mathport
     steps:
+      - name: clean up working directory
+        run: rm -rf *
+
+      - name: clean up elan
+        run: rm -rf $HOME/.elan
+
       - name: install elan
         run: |
           set -o pipefail


### PR DESCRIPTION
Too many CI builds are failing because the disk is full. Let's delete everything before *and* after the build.