### PR TITLE
bump: nightly-2021-12-15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@
 # This is useful if you are testing a change to mathport.
 
 ## Prerequisites:
-# curl, git, cmake, elan, python3
+# curl, git, cmake, elan
 
 # We make the following assumptions about versions:
 #

--- a/Mathport/Syntax/Translate/Basic.lean
+++ b/Mathport/Syntax/Translate/Basic.lean
@@ -1282,9 +1282,17 @@ def trCommand' : Command → M Unit
       warn! "unsupported: hide command"
       -- pushM `(hide $(ops.map fun n => mkIdent n.kind)*)
   | Command.theory #[⟨_, Modifier.noncomputable⟩] =>
-    pushM `(command| noncomputable theory)
-  | Command.theory #[⟨_, Modifier.doc doc⟩, ⟨_, Modifier.noncomputable⟩] =>
-    pushM `(command| $(trDocComment doc):docComment noncomputable theory)
+    pushM `(command| noncomputable section)
+  -- FIXME: Lean 4 does not currently allow a doc comment on
+  -- `noncomputable section`.
+  -- In any case, mathlib does not put doc comments on `noncomputable theory`
+  -- (there are many module docs before `noncomputable theory`,
+  -- but no doc comments).
+  -- For now, I've just commented out handling this case.
+  -- I would be happy to actually delete this case,
+  -- but will leave it in place for now.
+  -- | Command.theory #[⟨_, Modifier.doc doc⟩, ⟨_, Modifier.noncomputable⟩] =>
+  --   pushM `(command| $(trDocComment doc):docComment noncomputable section)
   | Command.theory _ => warn! "unsupported (impossible)"
   | Command.setOption o val => match o.kind, val.kind with
     | `old_structure_cmd, OptionVal.bool b =>

--- a/Mathport/Util/Misc.lean
+++ b/Mathport/Util/Misc.lean
@@ -91,17 +91,19 @@ def Subarray.getOp {α : Type u} [Inhabited α] (self : Subarray α) (idx : Nat)
 
 instance : Coe (Array α) (Subarray α) := ⟨(·[0:])⟩
 
-/-- Run action with `stdin` emptied and `stdout+stderr` captured into a `String`. -/
-def IO.FS.withIsolatedStreams' [Monad m] [MonadFinally m] [MonadLiftT IO m] (x : m α) : m (String × α) := do
-  let bIn ← mkRef { : Stream.Buffer }
-  let bOut ← mkRef { : Stream.Buffer }
-  let r ← withStdin (Stream.ofBuffer bIn) <|
-    withStdout (Stream.ofBuffer bOut) <|
-      withStderr (Stream.ofBuffer bOut) <|
-        x
-  let bOut ← liftM (m := IO) bOut.get
-  let out := String.fromUTF8Unchecked bOut.data
-  pure (out, r)
+-- TODO: This broke when bumping Lean 4 to nightly-2021-12-15.
+-- However it is not actually used in `mathport`, so I've just commented it out for now.
+-- /-- Run action with `stdin` emptied and `stdout+stderr` captured into a `String`. -/
+-- def IO.FS.withIsolatedStreams' [Monad m] [MonadFinally m] [MonadLiftT IO m] (x : m α) : m (String × α) := do
+--   let bIn ← mkRef { : Stream.Buffer }
+--   let bOut ← mkRef { : Stream.Buffer }
+--   let r ← withStdin (Stream.ofBuffer bIn) <|
+--     withStdout (Stream.ofBuffer bOut) <|
+--       withStderr (Stream.ofBuffer bOut) <|
+--         x
+--   let bOut ← liftM (m := IO) bOut.get
+--   let out := String.fromUTF8Unchecked bOut.data
+--   pure (out, r)
 
 def Lean.Syntax.mkCharLit (val : Char) (info := SourceInfo.none) : Syntax :=
   mkLit charLitKind (Char.quote val) info

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -9,7 +9,7 @@ package mathport {
     -- as changes to tactics in mathlib4 may cause breakages here.
     -- Please ensure that `lean-toolchain` points to the same release of Lean 4
     -- as this commit of mathlib4 uses.
-    src := Source.git "https://github.com/leanprover-community/mathlib4.git" "b9d13f475727bb0aea3e7cf257810b488ad53804"
+    src := Source.git "https://github.com/leanprover-community/mathlib4.git" "5c7f349f8fb75c53901dd0405543e02052fd55f1"
   }],
   binRoot := `MathportApp
   moreLinkArgs := if Platform.isWindows then #[] else #["-rdynamic"]

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2021-12-13
+leanprover/lean4:nightly-2021-12-15


### PR DESCRIPTION
Hopefully this will resolve the problems with `lake` in the downstream `lean3port` and `mathlib3port`?