### PR TITLE
feat: mathport_rules

### DIFF
--- a/Mathport/Syntax/Transform.lean
+++ b/Mathport/Syntax/Transform.lean
@@ -13,14 +13,5 @@ namespace Transform
 
 open Lean Elab Term
 
-local elab "mathportTransformerList%" : term => do
-  let decls := transformerAttr.getDecls (← getEnv) |>.map mkCIdent
-  Elab.Term.elabTerm (← `((#[$[$decls:term],*] : Array Transformer))) none
-
-partial def transform (stx : Syntax) : M Syntax :=
-  let transformers := mathportTransformerList%
-  stx.rewriteBottomUpM fun stx => do
-    for tr in transformers do
-      if let some stx' ← catchUnsupportedSyntax do tr stx then
-        return ← transform stx'
-    return stx
+partial def transform : Syntax → M Syntax :=
+  applyTransformers mathportTransformerList%

--- a/Mathport/Syntax/Transform.lean
+++ b/Mathport/Syntax/Transform.lean
@@ -1,0 +1,26 @@
+/-
+Copyright (c) 2021 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Gabriel Ebner
+-/
+import Mathport.Syntax.Transform.Basic
+import Mathport.Syntax.Transform.Declaration
+import Mathport.Syntax.Transform.Tactic
+import Mathlib.Tactic.Lint.Frontend
+
+namespace Mathport
+namespace Transform
+
+open Lean Elab Term
+
+local elab "mathportTransformerList%" : term => do
+  let decls := transformerAttr.getDecls (← getEnv) |>.map mkCIdent
+  Elab.Term.elabTerm (← `((#[$[$decls:term],*] : Array Transformer))) none
+
+partial def transform (stx : Syntax) : M Syntax :=
+  let transformers := mathportTransformerList%
+  stx.rewriteBottomUpM fun stx => do
+    for tr in transformers do
+      if let some stx' ← catchUnsupportedSyntax do tr stx then
+        return ← transform stx'
+    return stx

--- a/Mathport/Syntax/Transform/Basic.lean
+++ b/Mathport/Syntax/Transform/Basic.lean
@@ -1,0 +1,37 @@
+/-
+Copyright (c) 2021 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Gabriel Ebner
+-/
+import Mathport.Syntax.Translate.Basic
+
+namespace Mathport
+namespace Transform
+
+open Lean
+
+abbrev M := Translate.M
+
+abbrev Transformer := Syntax → M Syntax
+
+def throwUnsupported : M α := Elab.throwUnsupportedSyntax
+
+initialize transformerAttr : TagAttribute ←
+  registerTagAttribute `mathportTransformer "Lean 4 → 4 syntax transformation for prettification"
+    (validate := fun declName => do
+      let info ← getConstInfo declName
+      unless info.type.isConstOf ``Transformer do
+        throwError "declaration must have type {mkConst ``Transformer}")
+
+def matchAlts := Parser.Term.matchAlts
+syntax "mathport_rules " matchAlts : command
+
+open Elab in
+def catchUnsupportedSyntax (k : M α) : M (Option α) :=
+  catchInternalId unsupportedSyntaxExceptionId (some <$> k) (fun _ => none)
+
+open Elab.Command in
+macro_rules
+  | `(mathport_rules $[$alts:matchAlt]*) =>
+    `(@[mathportTransformer] aux_def mathportRules : Transformer :=
+      fun $[$alts:matchAlt]* | _ => throwUnsupported)

--- a/Mathport/Syntax/Transform/Basic.lean
+++ b/Mathport/Syntax/Transform/Basic.lean
@@ -8,13 +8,17 @@ import Mathport.Syntax.Translate.Basic
 namespace Mathport
 namespace Transform
 
-open Lean
+open Lean Elab Elab.Command
 
-abbrev M := Translate.M
+abbrev M := CommandElabM
 
 abbrev Transformer := Syntax → M Syntax
 
 def throwUnsupported : M α := Elab.throwUnsupportedSyntax
+
+open Elab in
+def catchUnsupportedSyntax (k : M α) : M (Option α) :=
+  catchInternalId unsupportedSyntaxExceptionId (some <$> k) (fun _ => none)
 
 initialize transformerAttr : TagAttribute ←
   registerTagAttribute `mathportTransformer "Lean 4 → 4 syntax transformation for prettification"
@@ -26,12 +30,24 @@ initialize transformerAttr : TagAttribute ←
 def matchAlts := Parser.Term.matchAlts
 syntax "mathport_rules " matchAlts : command
 
-open Elab in
-def catchUnsupportedSyntax (k : M α) : M (Option α) :=
-  catchInternalId unsupportedSyntaxExceptionId (some <$> k) (fun _ => none)
-
 open Elab.Command in
 macro_rules
   | `(mathport_rules $[$alts:matchAlt]*) =>
     `(@[mathportTransformer] aux_def mathportRules : Transformer :=
       fun $[$alts:matchAlt]* | _ => throwUnsupported)
+
+scoped elab "mathportTransformerList%" : term => do
+  let decls := transformerAttr.getDecls (← getEnv) |>.map mkCIdent
+  Elab.Term.elabTerm (← `((#[$[$decls:term],*] : Array Transformer))) none
+
+partial def applyTransformers (transformers : Array Transformer) (stx : Syntax) : M Syntax :=
+  stx.rewriteBottomUpM fun stx => do
+    for tr in transformers do
+      if let some stx' ← catchUnsupportedSyntax do tr stx then
+        return ← applyTransformers transformers stx'
+    return stx
+
+open PrettyPrinter in
+macro "#mathport_transform " stx:(term <|> command) : command =>
+  `(run_cmd logInfo <|<-
+    applyTransformers mathportTransformerList% (Unhygienic.run `($stx)))

--- a/Mathport/Syntax/Transform/Declaration.lean
+++ b/Mathport/Syntax/Transform/Declaration.lean
@@ -10,3 +10,8 @@ mathport_rules
       { $[$fieldName:ident := $fieldVal:term $[,]?]* }) =>
     `($mods:declModifiers $attr:attrKind instance $[$prio:namedPrio]? $[$id:declId]? $sig:declSig where
         $[$fieldName:ident := $fieldVal:term]*)
+
+open Lean.Parser.Command in
+mathport_rules
+  | `(whereStructField| $id:ident := fun $xs:ident* => $val:term) =>
+    `(whereStructField| $id:ident $xs:ident* := $val:term)

--- a/Mathport/Syntax/Transform/Declaration.lean
+++ b/Mathport/Syntax/Transform/Declaration.lean
@@ -1,0 +1,12 @@
+/-
+Copyright (c) 2021 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Gabriel Ebner
+-/
+import Mathport.Syntax.Transform.Basic
+
+mathport_rules
+  | `($mods:declModifiers $attr:attrKind instance $[$prio:namedPrio]? $[$id:declId]? $sig:declSig :=
+      { $[$fieldName:ident := $fieldVal:term $[,]?]* }) =>
+    `($mods:declModifiers $attr:attrKind instance $[$prio:namedPrio]? $[$id:declId]? $sig:declSig where
+        $[$fieldName:ident := $fieldVal:term]*)

--- a/Mathport/Syntax/Transform/Tactic.lean
+++ b/Mathport/Syntax/Transform/Tactic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Gabriel Ebner
 -/
 import Mathport.Syntax.Transform.Basic
+import Lean
 
 namespace Mathport
 namespace Transform
@@ -12,8 +13,8 @@ open Lean Elab
 def transformConsecutiveTactics : Syntax → Syntax → M Syntax
   | `(tactic| suffices : $ty:term), `(tactic|· $seq:tacticSeq) =>
     `(tactic| suffices $ty:term by $seq:tacticSeq)
-  | `(tactic| have $id:ident : $ty:term), `(tactic|· $seq:tacticSeq) =>
-    `(tactic| have $id:ident : $ty:term := by $seq:tacticSeq)
+  | `(tactic| have $[$id:ident]? $[: $ty:term]?), `(tactic|· $seq:tacticSeq) =>
+    `(tactic| have $[$id:ident]? $[: $ty:term]? := by $seq:tacticSeq)
   | _, _ => throwUnsupported
 
 mathport_rules
@@ -22,6 +23,5 @@ mathport_rules
       if let some tac' ← catchUnsupportedSyntax do
           transformConsecutiveTactics tacs[i-1][0] tacs[i][0] then
         let tacs' := tacs[0:i-1] ++ #[tacs[i].setArg 0 tac'] ++ tacs[i+1:tacs.size]
-        dbg_trace tacs'
         return Syntax.node info ``Parser.Tactic.tacticSeq1Indented #[Syntax.node info2 `null tacs']
     throwUnsupported

--- a/Mathport/Syntax/Transform/Tactic.lean
+++ b/Mathport/Syntax/Transform/Tactic.lean
@@ -1,0 +1,27 @@
+/-
+Copyright (c) 2021 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Gabriel Ebner
+-/
+import Mathport.Syntax.Transform.Basic
+
+namespace Mathport
+namespace Transform
+open Lean Elab
+
+def transformConsecutiveTactics : Syntax → Syntax → M Syntax
+  | `(tactic| suffices : $ty:term), `(tactic|· $seq:tacticSeq) =>
+    `(tactic| suffices $ty:term by $seq:tacticSeq)
+  | `(tactic| have $id:ident : $ty:term), `(tactic|· $seq:tacticSeq) =>
+    `(tactic| have $id:ident : $ty:term := by $seq:tacticSeq)
+  | _, _ => throwUnsupported
+
+mathport_rules
+  | Syntax.node info ``Parser.Tactic.tacticSeq1Indented #[Syntax.node info2 `null tacs] => do
+    for i in [1:tacs.size] do
+      if let some tac' ← catchUnsupportedSyntax do
+          transformConsecutiveTactics tacs[i-1][0] tacs[i][0] then
+        let tacs' := tacs[0:i-1] ++ #[tacs[i].setArg 0 tac'] ++ tacs[i+1:tacs.size]
+        dbg_trace tacs'
+        return Syntax.node info ``Parser.Tactic.tacticSeq1Indented #[Syntax.node info2 `null tacs']
+    throwUnsupported

--- a/Mathport/Syntax/Translate.lean
+++ b/Mathport/Syntax/Translate.lean
@@ -26,7 +26,7 @@ partial def M.run' (m : M α) (notations : Array Notation) (commands : Array Com
   let s ← ST.mkRef {}
   let rec ctx := {
     pcfg, notations, commands
-    transform := fun stx => Transform.transform stx ctx s
+    transform := Transform.transform
     trExpr := fun e => trExpr' e ctx s
     trCommand := fun c => trCommand' c ctx s }
   m ctx s

--- a/Mathport/Syntax/Translate.lean
+++ b/Mathport/Syntax/Translate.lean
@@ -8,6 +8,7 @@ import Mathport.Syntax.Translate.Attributes
 import Mathport.Syntax.Translate.Notation
 import Mathport.Syntax.Translate.Parser
 import Mathport.Syntax.Translate.Tactic
+import Mathport.Syntax.Transform
 
 namespace Mathport
 
@@ -25,6 +26,7 @@ partial def M.run' (m : M α) (notations : Array Notation) (commands : Array Com
   let s ← ST.mkRef {}
   let rec ctx := {
     pcfg, notations, commands
+    transform := fun stx => Transform.transform stx ctx s
     trExpr := fun e => trExpr' e ctx s
     trCommand := fun c => trCommand' c ctx s }
   m ctx s

--- a/Mathport/Syntax/Translate/Basic.lean
+++ b/Mathport/Syntax/Translate/Basic.lean
@@ -123,6 +123,7 @@ structure Context where
   commands : Array Command
   trExpr : Expr → CommandElabM Syntax
   trCommand : Command → CommandElabM Unit
+  transform : Syntax → CommandElabM Syntax
   deriving Inhabited
 
 abbrev M := ReaderT Context $ StateRefT State CommandElabM
@@ -212,6 +213,8 @@ def reprint (stx : Syntax) : Format :=
   reprintCore stx |>.getD ""
 
 def push (stx : Syntax) : M Unit := do
+  let stx ← try (← read).transform stx catch ex =>
+    warn! "failed to transform: {← ex.toMessageData.toString}" | stx
   let fmt ← liftCoreM $ do
     let (stx, parenthesizerErr) ←
       try (← Lean.PrettyPrinter.parenthesizeCommand stx, f!"")

--- a/config.json
+++ b/config.json
@@ -48,6 +48,6 @@
     ],
     "sorries": [],
     "skipProofs": false,
-    "parallel" : false,
+    "parallel" : true,
     "error2warning" : false
 }


### PR DESCRIPTION
Adds a `mathport_rules` command that allows rewriting the syntax after translation.  For example the following makes `instance` declarations use `where blocks:
```lean
mathport_rules
  | `(instance $[$id:declId]? $sig:declSig := { $[$fieldName:ident := $fieldVal:term $[,]?]* }) =>
    `(instance $[$id:declId]? $sig:declSig where $[$fieldName:ident := $fieldVal:term]*)
```
(The code includes the full rule, which also matches docstrings, etc.)

The above rule will only pretty-print nicely starting with tomorrow's nightly, so let's wait with merging this PR.