### PR TITLE
feat: add support for extBinders in notation3

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -9,7 +9,7 @@ package mathport {
     -- as changes to tactics in mathlib4 may cause breakages here.
     -- Please ensure that `lean-toolchain` points to the same release of Lean 4
     -- as this commit of mathlib4 uses.
-    src := Source.git "https://github.com/leanprover-community/mathlib4.git" "2d095db75460550eead477e47dfcc3488ca83e15"
+    src := Source.git "https://github.com/leanprover-community/mathlib4.git" "d159857c34b79ff8be78b6ab0919effe9052d785"
   }],
   binRoot := `MathportApp
   moreLinkArgs := if Platform.isWindows then #[] else #["-rdynamic"]

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -9,7 +9,7 @@ package mathport {
     -- as changes to tactics in mathlib4 may cause breakages here.
     -- Please ensure that `lean-toolchain` points to the same release of Lean 4
     -- as this commit of mathlib4 uses.
-    src := Source.git "https://github.com/leanprover-community/mathlib4.git" "d159857c34b79ff8be78b6ab0919effe9052d785"
+    src := Source.git "https://github.com/leanprover-community/mathlib4.git" "640a762da71c7d429a25acb34475fa6db3c0e25b"
   }],
   binRoot := `MathportApp
   moreLinkArgs := if Platform.isWindows then #[] else #["-rdynamic"]


### PR DESCRIPTION
The mathport counterpart of leanprover-community/mathlib4#142 : since `notation3` uses `extBinders` instead of `explicitBinders`, the syntax generation has to accommodate the new syntax kind (and associated grammar changes). Depends on leanprover-community/mathlib4#144 .