### PR TITLE
fix: trim doc comment

### DIFF
--- a/Mathport/Syntax/Translate/Basic.lean
+++ b/Mathport/Syntax/Translate/Basic.lean
@@ -283,7 +283,7 @@ def mkOptionalNodeM [Monad m] (x : Option α) (f : α → m (Array Syntax)) : m 
   | some a => f a
 
 def trDocComment (doc : String) : Syntax :=
-  mkNode ``Parser.Command.docComment #[mkAtom "/--", mkAtom (doc ++ "-/")]
+  mkNode ``Parser.Command.docComment #[mkAtom "/--", mkAtom (doc.trimLeft ++ "-/")]
 
 partial def scientificLitOfDecimal (num den : Nat) : Option Syntax :=
   findExp num den 0 |>.map fun (m, e) =>


### PR DESCRIPTION
The Lean 4 doc comment parser also trims the doc comments on the left side.  There is a discussion to be had about whether `/--` should be followed by a newline or not, but I'd like to stay consistent with core.