### PR TITLE
feat: simplify trTactic, add more transforms

### DIFF
--- a/Mathport/Syntax/Transform/Tactic.lean
+++ b/Mathport/Syntax/Transform/Tactic.lean
@@ -36,13 +36,51 @@ mathport_rules
 
 -- common obsolete patterns from haveI
 mathport_rules
-  | `(by have $hd:haveDecl; exact $t) => `(have $hd:haveDecl; $t)
-  | `(by have $hd:haveDecl <;> exact $t) => `(have $hd:haveDecl; $t)
+  | `(by have $hd:haveDecl
+         exact $t) =>
+    `(have $hd:haveDecl
+      $t)
+  | `(by have $hd:haveDecl <;> exact $t) =>
+    `(have $hd:haveDecl
+      $t)
 
 -- used in Lean 3 to postpone elaboration, now happens by default
 mathport_rules | `(by exact $t) => t
 
+mathport_rules
+  | `(tactic| · · $seq:tacticSeq) => `(tactic| · $seq:tacticSeq)
+  | `(conv| · · $seq:convSeq) => `(conv| · $seq:convSeq)
+
 mathport_rules | `(by · $seq:tacticSeq) => `(by $seq:tacticSeq)
+
+mathport_rules
+  | `(Parser.Term.binderTactic| := by · $seq:tacticSeq) =>
+    `(Parser.Term.binderTactic| := by $seq:tacticSeq)
+
+mathport_rules
+  | `(show $ty:term from by $seq:tacticSeq) =>
+    `(show $ty:term by $seq:tacticSeq)
+  | `(suffices $ty:term from by $seq:tacticSeq
+      $t) =>
+    `(suffices $ty:term by $seq:tacticSeq
+      $t)
+  | `(tactic| suffices $ty:term from by $seq:tacticSeq) =>
+    `(tactic| suffices $ty:term by $seq:tacticSeq)
+
+-- push `by` before `have`, `let`, `suffices` so that it can be formatted at the end of a line
+mathport_rules
+  | `(have $hd:haveDecl
+      by $[$seq:tactic]*) =>
+    `(by have $hd:haveDecl
+        $[$seq:tactic]*)
+  | `(let $ld:letDecl
+      by $[$seq:tactic]*) =>
+    `(by let $ld:letDecl
+        $[$seq:tactic]*)
+  | `(suffices $sd:sufficesDecl
+      by $[$seq:tactic]*) =>
+    `(by suffices $sd:sufficesDecl
+        $[$seq:tactic]*)
 
 -- expand `by (skip; skip)` to `by skip; skip`
 mathport_rules

--- a/Mathport/Syntax/Translate.lean
+++ b/Mathport/Syntax/Translate.lean
@@ -49,4 +49,4 @@ def AST3toData4 (ast : AST3) : (pcfg : Path.Config) → CommandElabM Data4 :=
   (Translate.AST3toData4 ast).run ast.indexed_nota ast.indexed_cmds
 
 def tactic3toSyntax (containingFile : AST3) (tac3 : AST3.Tactic) : (pcfg : Path.Config) → CommandElabM Syntax :=
-  (Translate.trTactic tac3 Translate.TacticContext.one).run containingFile.indexed_nota containingFile.indexed_cmds
+  (Translate.trTactic tac3).run containingFile.indexed_nota containingFile.indexed_cmds

--- a/Mathport/Syntax/Translate/Tactic/Lean3.lean
+++ b/Mathport/Syntax/Translate/Tactic/Lean3.lean
@@ -189,7 +189,7 @@ def trRwArgs : TacM (Array Syntax × Option Syntax) := do
 
 @[trTactic skip] def trSkip : TacM Syntax := `(tactic| skip)
 
-@[trTactic solve1] def trSolve1 : TacM Syntax := do trBlock (← itactic) TacticContext.one
+@[trTactic solve1] def trSolve1 : TacM Syntax := do `(tactic| · $(← trBlock (← itactic)):tacticSeq)
 
 @[trTactic abstract] def trAbstract : TacM Syntax := do
   `(tactic| abstract $(← liftM $ (← parse (ident)?).mapM mkIdentF)?


### PR DESCRIPTION
The simplification eliminates the `TacticContext` flag entirely. Now `trTactic` always produces a `tactic`, and `trBlock` always produces a `tacticSeq`. When these are mismatched, it is possible for an extra `by · $seq` to be introduced, so the transform stage eliminates this (also `:= by · $seq` which is technically a separate grammar production).

Also adds a bunch more transforms:

* `· · $seq` probably won't come up much but I think it is a possible result of the unoptimized translation. I decided against doing `· $seq; · $seq2` -> `· $seq; $seq2` because it is not uncommon to see this construction after a `by_cases` where we don't want to break the symmetry of subgoals.
* `from by` -> `by` in `show` and `suffices` (which I think is the only place this can arise, but I did not check)
* Move `by` before `have`, `let` and `suffices`, because this leads to better indentation:
```lean
theorem foo : 1 = 1 :=
  let a : Nat := 1
  have : a = a := rfl
  by
    symm
    rfl
```
becomes
```lean
theorem foo : 1 = 1 := by
  let a : Nat := 1
  have : a = a := rfl
  symm
  rfl
```
There might be some exceptions where the term mode have looks better, but in my manual porting I saw this pattern appear a lot so I think it is better on balance.