### PR TITLE
fix: assorted backtrack exception bugfixes

### DIFF
--- a/Mathport/Syntax/Translate/Tactic/Mathlib/Apply.lean
+++ b/Mathport/Syntax/Translate/Tactic/Mathlib/Apply.lean
@@ -23,7 +23,9 @@ open AST3 Parser
   `(tactic| eapply' $(← trExpr (← parse pExpr)))
 
 @[trTactic apply_with'] def trApplyWith' : TacM Syntax := do
-  `(tactic| apply_with' $(← trExpr (← parse pExpr)))
+  let e ← trExpr (← parse pExpr)
+  let cfg ← liftM $ (← expr?).mapM trExpr
+  `(tactic| apply_with' $[(config := $cfg)]? $e)
 
 @[trTactic mapply'] def trMApply' : TacM Syntax := do
   `(tactic| mapply' $(← trExpr (← parse pExpr)))

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -9,7 +9,7 @@ package mathport {
     -- as changes to tactics in mathlib4 may cause breakages here.
     -- Please ensure that `lean-toolchain` points to the same release of Lean 4
     -- as this commit of mathlib4 uses.
-    src := Source.git "https://github.com/leanprover-community/mathlib4.git" "c11fbda2470fda8c7dbd71d3e9c20b3195cce5b6"
+    src := Source.git "https://github.com/leanprover-community/mathlib4.git" "5903a6648bc010f2f8fd7bd1ba01cb9bdfdce052"
   }],
   binRoot := `MathportApp
   moreLinkArgs := if Platform.isWindows then #[] else #["-rdynamic"]


### PR DESCRIPTION
Most of these changes are not so interesting, but we can now compile all of lean3 and a decent chunk of mathlib (running locally now) with zero backtrack exceptions.

@gebner The changes in `Syntax/Transform/Tactic.lean` might interest you. The first change removes a redundant match arm; this was doubly surprising since it both did not warn/error on the duplicate branch, and it also did not elaborate the body at all, so there was no warning about the fact that the variable `seq` referenced in that branch does not exist. The second change is a workaround for leanprover/lean4#917 : `suffices T by exact x` was getting replaced by `suffices T x`, and there doesn't seem to be an easy way to avoid this with the bottom up syntax transform mechanism.