### PR TITLE
feat: translate comments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,11 +90,11 @@ LEANBIN_LIB=./Outputs/oleans/leanbin
 MATHBIN_LIB=./Outputs/oleans/mathbin
 
 port-lean: init-logs build
-	LEAN_PATH=$(MATHPORT_LIB):$(MATHLIB4_LIB):$(LEANBIN_LIB) ./build/bin/mathport config.json Leanbin::all >> Logs/mathport.out 2> >(tee -a Logs/mathport.err >&2)
+	./build/bin/mathport config.json Leanbin::all >> Logs/mathport.out 2> >(tee -a Logs/mathport.err >&2)
 	cp lean-toolchain Lean4Packages/lean3port/
 
 port-mathbin: port-lean
-	LEAN_PATH=$(MATHPORT_LIB):$(MATHLIB4_LIB):$(LEANBIN_LIB):$(MATHBIN_LIB) ./build/bin/mathport config.json Leanbin::all Mathbin::all >> Logs/mathport.out 2> >(tee -a Logs/mathport.err >&2)
+	./build/bin/mathport config.json Leanbin::all Mathbin::all >> Logs/mathport.out 2> >(tee -a Logs/mathport.err >&2)
 	cp lean-toolchain Lean4Packages/mathlib3port/
 
 port: port-lean port-mathbin
@@ -105,14 +105,10 @@ port: port-lean port-mathbin
 # or run `make build source` and `./download-release.sh nightly-YYYY-MM-DD`.
 
 port-lean-single:
-	rm -f Outputs/src/leanbin/Leanbin/$(subst .,/,$(TARGET)).lean
-	rm -f Outputs/oleans/leanbin/Leanbin/$(subst .,/,$(TARGET)).olean
-	LEAN_PATH=$(MATHPORT_LIB):$(MATHLIB4_LIB):$(LEANBIN_LIB) ./build/bin/mathport config.json Leanbin::$(TARGET)
+	./build/bin/mathport config.json Leanbin::$(TARGET)
 
 port-mathbin-single:
-	rm -f Outputs/src/mathbin/Mathbin/$(subst .,/,$(TARGET)).lean
-	rm -f Outputs/oleans/mathbin/Mathbin/$(subst .,/,$(TARGET)).olean
-	LEAN_PATH=$(MATHPORT_LIB):$(MATHLIB4_LIB):$(LEANBIN_LIB):$(MATHBIN_LIB) ./build/bin/mathport config.json Mathbin::$(TARGET)
+	./build/bin/mathport config.json Mathbin::$(TARGET)
 
 test-import-leanbin:
 	cd Test/importLeanbin && rm -rf build lean_packages && lake build

--- a/Mathport/Bridge/Path.lean
+++ b/Mathport/Bridge/Path.lean
@@ -22,6 +22,7 @@ def dot2path (dot : String) : FilePath :=
 structure Path.Config where
   outRoot  : FilePath
   packages : HashMap String FilePath -- "Mathlib" -> <mathlib3>/src
+  leanPath : List FilePath
   deriving Inhabited, FromJson
 
 structure Path where

--- a/Mathport/Syntax/AST3.lean
+++ b/Mathport/Syntax/AST3.lean
@@ -1164,7 +1164,7 @@ structure Comment where
   start : Position
   «end» : Position
   text : String
-  deriving Repr
+  deriving Repr, Inhabited
 
 end AST3
 

--- a/Mathport/Syntax/AST3.lean
+++ b/Mathport/Syntax/AST3.lean
@@ -124,7 +124,7 @@ structure Meta where
   deriving Inhabited
 
 structure Spanned (α : Type u) where
-  meta : Meta
+  meta : Option Meta
   kind  : α
   deriving Inhabited
 
@@ -133,7 +133,7 @@ instance [Repr α] : Repr (Spanned α) := ⟨fun n p => reprPrec n.kind p⟩
 def Spanned.map (f : α → β) : Spanned α → Spanned β
   | ⟨m, a⟩ => ⟨m, f a⟩
 
-def Spanned.dummy (a : α) : Spanned α := ⟨default, a⟩
+def Spanned.dummy (a : α) : Spanned α := ⟨none, a⟩
 
 local prefix:max "#" => Spanned
 

--- a/Mathport/Syntax/AST3.lean
+++ b/Mathport/Syntax/AST3.lean
@@ -1183,4 +1183,8 @@ instance : Repr AST3 where reprPrec
       "import " ++ Format.joinSep (ns.toList.map fun a => a.kind.toString) " " ++ "\n") ++
     "\n" ++ Format.join (cmds.toList.map fun c => repr c ++ "\n\n")
 
+partial def Spanned.unparen : #AST3.Expr → #AST3.Expr
+  | ⟨_, AST3.Expr.paren e⟩ => e.unparen
+  | e => e
+
 end Mathport

--- a/Mathport/Syntax/AST3.lean
+++ b/Mathport/Syntax/AST3.lean
@@ -1160,6 +1160,12 @@ instance : Repr TacticInvocation where reprPrec
     "before:\n" ++ Goals_repr start ++
     (if success then "success" else "failed") ++ ", after:\n" ++ Goals_repr end_
 
+structure Comment where
+  start : Position
+  «end» : Position
+  text : String
+  deriving Repr
+
 end AST3
 
 structure AST3 where
@@ -1168,9 +1174,10 @@ structure AST3 where
   commands : Array (Spanned AST3.Command)
   indexed_nota : Array AST3.Notation
   indexed_cmds : Array AST3.Command
+  comments : Array AST3.Comment
 
 instance : Repr AST3 where reprPrec
-  | ⟨prel, imps, cmds, _, _⟩, _ =>
+  | ⟨prel, imps, cmds, _, _, _⟩, _ =>
     (match prel with | none => "" | some _ => "prelude\n") ++
     Format.join (imps.toList.map fun ns =>
       "import " ++ Format.joinSep (ns.toList.map fun a => a.kind.toString) " " ++ "\n") ++

--- a/Mathport/Syntax/Parse.lean
+++ b/Mathport/Syntax/Parse.lean
@@ -78,7 +78,7 @@ def getCommandId (i : AstId) : M NotationId :=
 
 def RawNode3.map (i : AstId) (n : RawNode3)
   (f : String → Name → Array AstId → M α) : M (Spanned α) := do
-  pure ⟨⟨i, n.start, n.end'⟩, ← f n.kind n.value n.children'⟩
+  pure ⟨some ⟨i, n.start, n.end'⟩, ← f n.kind n.value n.children'⟩
 
 def RawNode3.pexpr' (n : RawNode3) : M Lean3.Expr :=
   match n.pexpr with
@@ -104,15 +104,15 @@ def withNodeK (f : String → Name → Array AstId → M α) (i : AstId) : M α 
 
 def withNode (f : String → Name → Array AstId → M α) (i : AstId) : M (Spanned α) := do
   let r ← getRaw i
-  pure { meta := ⟨i, r.start, r.end'⟩, kind := ← f r.kind r.value r.children' }
+  pure { meta := some ⟨i, r.start, r.end'⟩, kind := ← f r.kind r.value r.children' }
 
 def withNodeP (f : String → Name → Array AstId → Option ExprId → M α) (i : AstId) : M (Spanned α) := do
   let r ← getRaw i
-  pure { meta := ⟨i, r.start, r.end'⟩, kind := ← f r.kind r.value r.children' r.pexpr }
+  pure { meta := some ⟨i, r.start, r.end'⟩, kind := ← f r.kind r.value r.children' r.pexpr }
 
 def withNodeR (f : RawNode3 → M α) (i : AstId) : M (Spanned α) := do
   let r ← getRaw i
-  pure { meta := ⟨i, r.start, r.end'⟩, kind := ← f r }
+  pure { meta := some ⟨i, r.start, r.end'⟩, kind := ← f r }
 
 def getRaw? : AstId → M (Option RawNode3) := opt getRaw
 

--- a/Mathport/Syntax/Transform/Basic.lean
+++ b/Mathport/Syntax/Transform/Basic.lean
@@ -43,7 +43,7 @@ scoped elab "mathportTransformerList%" : term => do
 partial def applyTransformers (transformers : Array Transformer) (stx : Syntax) : M Syntax :=
   stx.rewriteBottomUpM fun stx => do
     for tr in transformers do
-      if let some stx' ← catchUnsupportedSyntax do tr stx then
+      if let some stx' ← catchUnsupportedSyntax do withRef stx do tr stx then
         return ← applyTransformers transformers stx'
     return stx
 

--- a/Mathport/Syntax/Transform/Tactic.lean
+++ b/Mathport/Syntax/Transform/Tactic.lean
@@ -25,7 +25,7 @@ def transformConsecutiveTactics : Syntax → Syntax → M Syntax
 
 def transformConsecutiveTacticsArray (tacs : Array Syntax) : M (Array Syntax) := do
   for i in [1:tacs.size] do
-    if let some tac' ← catchUnsupportedSyntax do
+    if let some tac' ← catchUnsupportedSyntax do withRef tacs[i-1] do
         transformConsecutiveTactics tacs[i-1] tacs[i] then
       return tacs[0:i-1] ++ #[tac'] ++ tacs[i+1:tacs.size]
   throwUnsupported

--- a/Mathport/Syntax/Translate.lean
+++ b/Mathport/Syntax/Translate.lean
@@ -48,5 +48,5 @@ end Translate
 def AST3toData4 (ast : AST3) : (pcfg : Path.Config) → CommandElabM Data4 :=
   (Translate.AST3toData4 ast).run ast.indexed_nota ast.indexed_cmds
 
-def tactic3toSyntax (containingFile : AST3) (tac3 : AST3.Tactic) : (pcfg : Path.Config) → CommandElabM Syntax :=
+def tactic3toSyntax (containingFile : AST3) (tac3 : Spanned AST3.Tactic) : (pcfg : Path.Config) → CommandElabM Syntax :=
   (Translate.trTactic tac3).run containingFile.indexed_nota containingFile.indexed_cmds

--- a/Mathport/Syntax/Translate.lean
+++ b/Mathport/Syntax/Translate.lean
@@ -9,6 +9,7 @@ import Mathport.Syntax.Translate.Notation
 import Mathport.Syntax.Translate.Parser
 import Mathport.Syntax.Translate.Tactic
 import Mathport.Syntax.Transform
+import Init.Data.Array.QSort
 
 namespace Mathport
 
@@ -31,8 +32,9 @@ partial def M.run' (m : M α) (notations : Array Notation) (commands : Array Com
     trCommand := fun c => trCommand' c ctx s }
   m ctx s
 
-def M.run (m : M α) : (notations : Array Notation) → (commands : Array Command) →
-  (pcfg : Path.Config) → CommandElabM α :=
+def M.run (m : M α) (comments : Array Comment) :
+    (notations : Array Notation) → (commands : Array Command) →
+    (pcfg : Path.Config) → CommandElabM α :=
   M.run' $ do
     let tactics ← Tactic.builtinTactics
     let niTactics ← Tactic.builtinNITactics
@@ -40,13 +42,15 @@ def M.run (m : M α) : (notations : Array Notation) → (commands : Array Comman
     let userNotas ← Tactic.builtinUserNotation
     let userAttrs ← Tactic.builtinUserAttrs
     let userCmds ← Tactic.builtinUserCmds
-    modify fun s => { s with tactics, niTactics, convs, userNotas, userAttrs, userCmds }
+    modify fun s => { s with
+      tactics, niTactics, convs, userNotas, userAttrs, userCmds,
+      remainingComments := comments.qsort (positionToStringPos ·.start < positionToStringPos ·.start) |>.toList }
     m
 
 end Translate
 
 def AST3toData4 (ast : AST3) : (pcfg : Path.Config) → CommandElabM Data4 :=
-  (Translate.AST3toData4 ast).run ast.indexed_nota ast.indexed_cmds
+  (Translate.AST3toData4 ast).run ast.comments ast.indexed_nota ast.indexed_cmds
 
 def tactic3toSyntax (containingFile : AST3) (tac3 : Spanned AST3.Tactic) : (pcfg : Path.Config) → CommandElabM Syntax :=
-  (Translate.trTactic tac3).run containingFile.indexed_nota containingFile.indexed_cmds
+  (Translate.trTactic tac3).run #[] containingFile.indexed_nota containingFile.indexed_cmds

--- a/Mathport/Syntax/Translate/Basic.lean
+++ b/Mathport/Syntax/Translate/Basic.lean
@@ -571,9 +571,9 @@ end
 
 def trBinderDefault : Default → M Syntax
   | Default.«:=» e => do `(Parser.Term.binderDefault| := $(← trExpr e))
-  | Default.«.» e => do
+  | Default.«.» ⟨m, e⟩ => do
     `(Parser.Term.binderTactic| := by
-      $(← trTactic (Spanned.dummy $ Tactic.expr $ e.map Expr.ident)):tactic)
+      $(← trTactic ⟨m, Tactic.expr ⟨m, Expr.ident e⟩⟩):tactic)
 
 def trBinary (n : Name) (lhs rhs : Syntax) : M Syntax := do
   match ← getNotationEntry? n.getString! with

--- a/Mathport/Syntax/Translate/Basic.lean
+++ b/Mathport/Syntax/Translate/Basic.lean
@@ -1236,7 +1236,7 @@ def trInductive (cl : Bool) (mods : Modifiers) (n : Spanned Name) (us : LevelDec
   let (s, mods) ← trModifiers mods
   let id ← trDeclId n.kind us
   let sig ← trDeclSig false bis ty
-  let ctors ← intros.mapM fun ⟨_, ⟨doc, name, ik, bis, ty⟩⟩ => do
+  let ctors ← intros.mapM fun ⟨m, ⟨doc, name, ik, bis, ty⟩⟩ => withSpanS m do
     `(Parser.Command.ctor| |
       $[$(doc.map trDocComment):docComment]?
       $(← mkIdentI name.kind):ident

--- a/Mathport/Syntax/Translate/Tactic/Basic.lean
+++ b/Mathport/Syntax/Translate/Tactic/Basic.lean
@@ -46,13 +46,13 @@ def parse (p : Parser.ParserM α) : TacM α := do
 
 def parse_0 (t : TacM α) := parse (pure ()) *> t
 
-def expr? : TacM (Option AST3.Expr) := do
+def expr? : TacM (Option (Spanned AST3.Expr)) := do
   match ← next? with
   | none => pure none
-  | some (Param.expr e) => pure $ some e.kind
+  | some (Param.expr e) => pure e
   | _ => warn! "parse error"
 
-def expr! : TacM AST3.Expr := do
+def expr! : TacM (Spanned AST3.Expr) := do
   match ← expr? with | some p => pure p | none => warn! "missing argument"
 
 def itactic : TacM AST3.Block := do

--- a/Mathport/Syntax/Translate/Tactic/Lean3.lean
+++ b/Mathport/Syntax/Translate/Tactic/Lean3.lean
@@ -182,7 +182,7 @@ def trRwArgs : TacM (Array Syntax × Option Syntax) := do
   | none, tac => `(tactic| repeat $tac:tacticSeq)
   | some n, tac => `(tactic| iterate $(Quote.quote n) $tac:tacticSeq)
 
-@[trTactic repeat] def trRepeat : TacM Syntax := do
+@[trTactic «repeat»] def trRepeat : TacM Syntax := do
   `(tactic| repeat' $(← trBlock (← itactic)):tacticSeq)
 
 @[trTactic «try»] def trTry : TacM Syntax := do `(tactic| try $(← trBlock (← itactic)):tacticSeq)

--- a/Mathport/Syntax/Translate/Tactic/Mathlib/Core.lean
+++ b/Mathport/Syntax/Translate/Tactic/Mathlib/Core.lean
@@ -53,7 +53,7 @@ def trInterpolatedStr' := trInterpolatedStr fun stx => `(← $stx)
 
 @[trUserCmd «mk_simp_attribute»] def trMkSimpAttribute : TacM Syntax := do
   let (n, d, withList) ← parse $ return (← ident, ← pExpr, ← (tk "with" *> ident*)?)
-  let d ← match d.unparen with
+  let d ← match d.kind.unparen with
   | AST3.Expr.ident `none => pure $ none
   | AST3.Expr.string s => pure $ some (Syntax.mkStrLit s)
   | _ => warn! "unsupported: weird string"

--- a/Mathport/Syntax/Translate/Tactic/Mathlib/DocCommands.lean
+++ b/Mathport/Syntax/Translate/Tactic/Mathlib/DocCommands.lean
@@ -18,7 +18,7 @@ open AST3 Parser
   `(command| copy_doc_string $(← mkIdentI fr) → $(← liftM $ to_.mapM mkIdentI)*)
 
 @[trUserCmd «library_note»] def trLibraryNote (doc : Option String) : TacM Syntax := do
-  let Expr.string s ← parse pExpr | warn! "unsupported: weird string"
+  let ⟨_, Expr.string s⟩ ← parse pExpr | warn! "unsupported: weird string"
   `(command| library_note $(Syntax.mkStrLit s) $(trDocComment doc.get!):docComment)
 
 @[trUserCmd «add_tactic_doc»] def trAddTacticDoc (doc : Option String) : TacM Syntax := do

--- a/Mathport/Syntax/Translate/Tactic/Mathlib/Finish.lean
+++ b/Mathport/Syntax/Translate/Tactic/Mathlib/Finish.lean
@@ -13,7 +13,7 @@ open Parser
 
 -- # tactic.finish
 
-def trUsingList (args : Array AST3.Expr) : M Syntax :=
+def trUsingList (args : Array (Spanned AST3.Expr)) : M Syntax :=
   @mkNullNode <$> match args with
   | #[] => pure #[]
   | args => return #[mkAtom "using", (mkAtom ",").mkSep $ ← args.mapM trExpr]

--- a/Mathport/Syntax/Translate/Tactic/Mathlib/Hint.lean
+++ b/Mathport/Syntax/Translate/Tactic/Mathlib/Hint.lean
@@ -16,7 +16,7 @@ open AST3 Parser
 
 @[trUserCmd «add_hint_tactic»] def trAddHintTactic : TacM Syntax := do
   let tac ← match (← parse $ pExpr *> withInput pExpr).1 with
-  | Expr.«`[]» tacs => trIdTactic ⟨false, none, none, tacs⟩
+  | ⟨_, Expr.«`[]» tacs⟩ => trIdTactic ⟨false, none, none, tacs⟩
   | _ => warn! "unsupported (impossible)"
   `(command| add_hint_tactic $tac)
 

--- a/Mathport/Syntax/Translate/Tactic/Mathlib/Interactive.lean
+++ b/Mathport/Syntax/Translate/Tactic/Mathlib/Interactive.lean
@@ -41,7 +41,7 @@ open AST3 Parser
 
 @[trTactic swap] def trSwap : TacM Syntax := do
   let n ← (← expr?).mapM fun
-  | AST3.Expr.nat n => pure n
+  | ⟨_, AST3.Expr.nat n⟩ => pure n
   | _ => warn! "unsupported: weird nat"
   match n.getD 2 with
   | 1 => `(tactic| skip)
@@ -50,7 +50,7 @@ open AST3 Parser
 
 @[trTactic rotate] def trRotate : TacM Syntax := do
   let n ← (← expr?).mapM fun
-  | AST3.Expr.nat n => pure n
+  | ⟨_, AST3.Expr.nat n⟩ => pure n
   | _ => warn! "unsupported: weird nat"
   match n.getD 1 with
   | 0 => `(tactic| skip)
@@ -107,7 +107,7 @@ open AST3 Parser
   `(tactic| guard_hyp $(mkIdent (← parse ident)) : $(← trExpr (← parse (tk ":" *> pExpr))))
 
 @[trTactic guard_hyp_nums] def trGuardHypNums : TacM Syntax := do
-  match (← expr!).unparen with
+  match (← expr!).kind.unparen with
   | AST3.Expr.nat n => `(tactic| guard_hyp_nums $(Quote.quote n))
   | _ => warn! "unsupported: weird nat"
 
@@ -119,7 +119,7 @@ open AST3 Parser
 
 @[trTactic success_if_fail_with_msg] def trSuccessIfFailWithMsg : TacM Syntax := do
   let t ← trBlock (← itactic)
-  match (← expr!).unparen with
+  match (← expr!).kind.unparen with
   | AST3.Expr.string s => `(tactic| fail_if_success? $(Syntax.mkStrLit s) $t:tacticSeq)
   | _ => warn! "unsupported: weird string"
 
@@ -133,7 +133,7 @@ open AST3 Parser
 @[trTactic apply_rules] def trApplyRules : TacM Syntax := do
   let hs ← liftM $ (← parse pExprListOrTExpr).mapM trExpr
   let n ← (← expr?).mapM fun
-  | AST3.Expr.nat n => pure $ Quote.quote n
+  | ⟨_, AST3.Expr.nat n⟩ => pure $ Quote.quote n
   | _ => warn! "unsupported: weird nat"
   let cfg ← liftM $ (← expr?).mapM trExpr
   `(tactic| apply_rules $[(config := $cfg)]? [$hs,*] $(n)?)

--- a/Mathport/Syntax/Translate/Tactic/Mathlib/Misc1.lean
+++ b/Mathport/Syntax/Translate/Tactic/Mathlib/Misc1.lean
@@ -261,8 +261,8 @@ open AST3 Parser
 -- # tactic.slice
 
 @[trConv slice] def trSliceConv : TacM Syntax := do
-  let AST3.Expr.nat a ← expr! | warn! "slice: weird nat"
-  let AST3.Expr.nat b ← expr! | warn! "slice: weird nat"
+  let ⟨_, AST3.Expr.nat a⟩ ← expr! | warn! "slice: weird nat"
+  let ⟨_, AST3.Expr.nat b⟩ ← expr! | warn! "slice: weird nat"
   `(conv| slice $(Quote.quote a) $(Quote.quote b))
 
 @[trTactic slice_lhs] def trSliceLHS : TacM Syntax := do

--- a/Mathport/Syntax/Translate/Tactic/Mathlib/Misc2.lean
+++ b/Mathport/Syntax/Translate/Tactic/Mathlib/Misc2.lean
@@ -157,7 +157,7 @@ attribute [trNITactic try_refl_tac] trControlLawsTac
 @[trUserAttr to_additive] def trToAdditiveAttr : TacM Syntax := do
   let (bang, ques, tgt, doc) ← parse $ return (← (tk "!")?, ← (tk "?")?, ← (ident)?, ← (pExpr)?)
   let tgt ← liftM $ tgt.mapM mkIdentI
-  let doc ← doc.mapM fun doc => match doc.unparen with
+  let doc ← doc.mapM fun doc => match doc.kind.unparen with
   | Expr.string s => pure $ Syntax.mkStrLit s
   | _ => warn! "to_additive: weird doc string"
   match bang, ques with

--- a/Mathport/Syntax/Translate/Tactic/Mathlib/Misc2.lean
+++ b/Mathport/Syntax/Translate/Tactic/Mathlib/Misc2.lean
@@ -157,8 +157,8 @@ attribute [trNITactic try_refl_tac] trControlLawsTac
 @[trUserAttr to_additive] def trToAdditiveAttr : TacM Syntax := do
   let (bang, ques, tgt, doc) ← parse $ return (← (tk "!")?, ← (tk "?")?, ← (ident)?, ← (pExpr)?)
   let tgt ← liftM $ tgt.mapM mkIdentI
-  let doc ← doc.mapM fun doc => match doc.kind.unparen with
-  | Expr.string s => pure $ Syntax.mkStrLit s
+  let doc ← doc.mapM fun doc => match doc.unparen with
+  | ⟨m, Expr.string s⟩ => pure $ setInfo m $ Syntax.mkStrLit s
   | _ => warn! "to_additive: weird doc string"
   match bang, ques with
   | none, none => `(attr| to_additive $(tgt)? $(doc)?)

--- a/Mathport/Syntax/Translate/Tactic/Mathlib/Squeeze.lean
+++ b/Mathport/Syntax/Translate/Tactic/Mathlib/Squeeze.lean
@@ -26,7 +26,7 @@ open Parser
   let hs := trSimpList (← trSimpArgs (← parse simpArgList))
   let attrs := (← parse (tk "with" *> ident*)?).getD #[]
   let loc := mkOptionalNode $ ← trLoc (← parse location)
-  let (cfg, disch) ← parseSimpConfig (← parse (structInst)?)
+  let (cfg, disch) ← parseSimpConfig <| (← parse (structInst)?).map Spanned.dummy
   let cfg ← mkConfigStx $ cfg.bind quoteSimpConfig
   pure $ mkNode tac #[mkAtom s, cfg, disch, o, hs, trSimpAttrs attrs, loc]
 
@@ -40,7 +40,7 @@ open Parser
   let hs := trSimpList (← trSimpArgs (← parse simpArgList))
   let attrs := (← parse (tk "with" *> ident*)?).getD #[]
   let e ← liftM $ (← parse (tk "using" *> pExpr)?).mapM trExpr
-  let (cfg, disch) ← parseSimpConfig (← parse (structInst)?)
+  let (cfg, disch) ← parseSimpConfig <| (← parse (structInst)?).map Spanned.dummy
   let cfg ← mkConfigStx $ cfg.bind quoteSimpConfig
   pure $ mkNode tac #[mkAtom s, cfg, disch, o, hs, trSimpAttrs attrs,
     mkOptionalNode' e fun e => #[mkAtom "using", e]]
@@ -55,6 +55,6 @@ open Parser
   let hs := trSimpList (← trSimpArgs (← parse simpArgList))
   let attrs := (← parse (tk "with" *> ident*)?).getD #[]
   let loc := mkOptionalNode $ ← trLoc (← parse location)
-  let (cfg, _) ← parseSimpConfig (← parse (structInst)?)
+  let (cfg, _) ← parseSimpConfig <| (← parse (structInst)?).map Spanned.dummy
   let cfg ← mkConfigStx $ cfg.bind quoteSimpConfig
   pure $ mkNode tac #[mkAtom s, cfg, o, hs, trSimpAttrs attrs, loc]

--- a/MathportApp.lean
+++ b/MathportApp.lean
@@ -8,10 +8,7 @@ unsafe def main (args : List String) : IO Unit := do
     let config ← parseJsonFile Config pathToConfig
     let paths ← parsePaths pmod3s
     println! "[paths] {repr paths}"
-    let path := match ← IO.getEnv "LEAN_PATH" with
-    | none => []
-    | some path => System.SearchPath.parse path
-    searchPathRef.set (leanDir! :: path)
+    searchPathRef.set (leanDir! :: config.pathConfig.leanPath)
     mathport config paths.toArray
 
   | _ => throw $ IO.userError "usage: mathport <path-to-config> [pkg::mod3]+"

--- a/README.md
+++ b/README.md
@@ -50,9 +50,12 @@ The script `./download-release.sh nightly-YYYY-MM-DD` downloads one of these,
 after which you can skip the `make predata` and/or `make port` steps
 (you will still need to run `make build` and `make source`).
 
-You can also use the `make TARGET=data.nat.bitwise port-mathbin-single` target
-(similarly for `port-lean-single`) to run mathport on a single file.
-This is useful if you are testing a change to mathport.
+To port a single file, then execute `mathport` as follows
+(depending on whether you want to port a core or a mathlib file):
+```
+./build/bin/mathport config.json Leanbin::init.data.nat.gcd
+./build/bin/mathport config.json Mathbin::field_theory.abel_ruffini
+```
 
 The directory `Test` contains subdirectories `importLeanBin` and `importMathbin`,
 each containing a `lakefile.lean` that depends on one of the projects

--- a/config.json
+++ b/config.json
@@ -4,7 +4,12 @@
         "packages": {
             "Leanbin": "sources/lean/library",
             "Mathbin": "sources/mathlib/src"
-        }
+        },
+        "leanPath": [
+            "./lean_packages/mathlib/build/lib",
+            "./Outputs/oleans/leanbin",
+            "./Outputs/oleans/mathbin"
+        ]
     },
     "stringsToKeep": [
         "_sunfold",

--- a/download-release.sh
+++ b/download-release.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Script to download artifacts from a release.
 # Usage: `./download-release.sh nightly-2021-11-30`
 
@@ -10,46 +10,31 @@ if [ -z "$RELEASE" ]; then
     exit 1
 fi
 
+set -ex
+
 curl -O -L https://github.com/leanprover-community/mathport/releases/download/$RELEASE/lean3-predata.tar.gz
-mkdir -p PreData/Leanbin/
-mv lean3-predata.tar.gz PreData/Leanbin/
-cd PreData/Leanbin/
-tar zxvf lean3-predata.tar.gz
-rm lean3-predata.tar.gz
-cd ../../
+tar zxvf lean3-predata.tar.gz; rm lean3-predata.tar.gz
+
 curl -O -L https://github.com/leanprover-community/mathport/releases/download/$RELEASE/lean3-binport.tar.gz
 mkdir -p Outputs/oleans/leanbin/
 mv lean3-binport.tar.gz Outputs/oleans/leanbin/
-cd Outputs/oleans/leanbin/
-tar zxvf lean3-binport.tar.gz
-rm lean3-binport.tar.gz
-cd ../../../
+(cd Outputs/oleans/leanbin/; tar zxvf lean3-binport.tar.gz; rm lean3-binport.tar.gz)
+
 curl -O -L https://github.com/leanprover-community/mathport/releases/download/$RELEASE/lean3-synport.tar.gz
 mkdir -p Outputs/src/leanbin/
 mv lean3-synport.tar.gz Outputs/src/leanbin/
-cd Outputs/src/leanbin/
-tar zxvf lean3-synport.tar.gz
-rm lean3-synport.tar.gz
-cd ../../../
+(cd Outputs/src/leanbin/; tar zxvf lean3-synport.tar.gz; rm lean3-synport.tar.gz)
+
 curl -O -L https://github.com/leanprover-community/mathport/releases/download/$RELEASE/mathlib3-predata.tar.gz
-mkdir -p PreData/Mathbin/
-mv mathlib3-predata.tar.gz PreData/Mathbin/
-cd PreData/Mathbin/
-tar zxvf mathlib3-predata.tar.gz
-rm mathlib3-predata.tar.gz
-cd ../../
+tar zxvf mathlib3-predata.tar.gz; rm mathlib3-predata.tar.gz
+
 curl -O -L https://github.com/leanprover-community/mathport/releases/download/$RELEASE/mathlib3-binport.tar.gz
 mkdir -p Outputs/oleans/mathbin/
 mv mathlib3-binport.tar.gz Outputs/oleans/mathbin/
-cd Outputs/oleans/mathbin/
-tar zxvf mathlib3-binport.tar.gz
-rm mathlib3-binport.tar.gz
-cd ../../../
+(cd Outputs/oleans/mathbin/; tar zxvf mathlib3-binport.tar.gz; rm mathlib3-binport.tar.gz)
+
 curl -O -L https://github.com/leanprover-community/mathport/releases/download/$RELEASE/mathlib3-synport.tar.gz
 mkdir -p Outputs/src/mathbin/
 mv mathlib3-synport.tar.gz Outputs/src/mathbin/
-cd Outputs/src/mathbin/
-tar zxvf mathlib3-synport.tar.gz
-rm mathlib3-synport.tar.gz
-cd ../../../
+(cd Outputs/src/mathbin/; tar zxvf mathlib3-synport.tar.gz; rm mathlib3-synport.tar.gz)
 


### PR DESCRIPTION
This works by annotating the translated `Syntax` objects with synthetic positions from the Lean 3 source file (using 10000*line+column as the string position).  The `trExpr` function therefore now takes an argument of type `Spanned Expr` instead of `Expr` and implicitly uses `withRef` so that syntax quotations add the desired range.  If the resulting syntax still doesn't have a range (e.g. because it is constructed manually), then `trExpr` sets the info on the resulting syntax.  Before the syntax is printed (but after transformations), the comments are inserted into the syntax at reasonable positions.

Fixes #101 