### PR TITLE
feat: add support for fold notations

### DIFF
--- a/Mathport/Syntax/AST3.lean
+++ b/Mathport/Syntax/AST3.lean
@@ -1107,7 +1107,9 @@ def Notation.name (sp : Char) (f : PrecSymbol → String) (withTerm : Bool) (sta
     | Literal.var _ (some ⟨_, Action.prev⟩) => s := s.push sp
     | Literal.var _ (some ⟨_, Action.scoped _ _⟩) => s := s.push sp
     | Literal.var _ (some ⟨_, Action.fold _ _ sep _ _ term⟩) =>
-      s := s.push sp ++ f sep
+      -- TODO: restore after lean#687 lands
+      -- s := s.push sp ++ f sep
+      s := s.push sp ++ if withTerm then sep.1.kind.toString else f sep
       if withTerm then if let some term := term then s := s ++ f term
     | Literal.binder _ => s := s.push sp
     | Literal.binders _ => s := s.push sp

--- a/Mathport/Syntax/Translate/Basic.lean
+++ b/Mathport/Syntax/Translate/Basic.lean
@@ -1457,7 +1457,10 @@ def trNotationCmd (loc : LocalReserve) (attrs : Attributes) (nota : Notation)
     | _ => none
     let p ← p.mapM fun p => return (← trPrec p.kind).toSyntax
     let desc := match lits with
-    | #[⟨_, AST3.Literal.sym tk⟩] => NotationDesc.const tk.1.kind.toString
+    | #[⟨_, AST3.Literal.sym tk⟩] => NotationDesc.const tk.1.kind.trim
+    | #[⟨_, AST3.Literal.sym left⟩,
+        ⟨_, AST3.Literal.var v (some ⟨_, Action.fold _ _ sep _ _ (some term)⟩)⟩] =>
+      NotationDesc.exprs left.1.kind.trim sep.1.kind.trim term.1.kind.trim
     | _ => match mkNAry lits with
       | some lits => NotationDesc.nary lits
       | none => NotationDesc.fail

--- a/Mathport/Syntax/Translate/Notation.lean
+++ b/Mathport/Syntax/Translate/Notation.lean
@@ -40,6 +40,7 @@ inductive NotationDesc
   | «prefix» (tk : String)
   | «postfix» (tk : String)
   | nary (lits : Array Literal)
+  | exprs (left sep right : String)
   deriving FromJson, ToJson, Inhabited
 
 structure NotationEntry where
@@ -68,6 +69,9 @@ def NotationDesc.toKind (n4 : Name) : NotationDesc → NotationKind
   | NotationDesc.infix tk => NotationKind.binary fun a b => mkNode n4 #[a, mkAtom tk, b]
   | NotationDesc.prefix tk => NotationKind.unary fun a => mkNode n4 #[mkAtom tk, a]
   | NotationDesc.postfix tk => NotationKind.unary fun a => mkNode n4 #[a, mkAtom tk]
+  | NotationDesc.exprs left sep right =>
+    let left := mkAtom left; let sep := mkAtom sep; let right := mkAtom right
+    NotationKind.exprs fun as => mkNode n4 #[left, Syntax.mkSep as sep, right]
   | NotationDesc.nary lits => NotationKind.nary fun as => mkNode n4 $ lits.map fun
     | Literal.arg i => as.getD i Syntax.missing
     | Literal.tk tk => mkAtom tk


### PR DESCRIPTION
This is the mathport counterpart of leanprover-community/mathlib4#196, adding support for generating foldl notations. It works to translate the notation itself, but the uses of the notation still do not resolve correctly due to a bug in lean 3 notation name generation that is addressed in leanprover-community/lean#687.