### PR TITLE
refactor: use more syntax quotations, bump to nightly-2022-03-21

### DIFF
--- a/Mathport/Bridge/Path.lean
+++ b/Mathport/Bridge/Path.lean
@@ -20,9 +20,9 @@ def dot2path (dot : String) : FilePath :=
   System.mkFilePath $ dot.splitOn "."
 
 structure Path.Config where
-  outRoot  : FilePath
-  packages : HashMap String FilePath -- "Mathlib" -> <mathlib3>/src
-  leanPath : List FilePath
+  outRoot  : FilePath := ""
+  packages : HashMap String FilePath := {} -- "Mathlib" -> <mathlib3>/src
+  leanPath : List FilePath := []
   deriving Inhabited, FromJson
 
 structure Path where

--- a/Mathport/Syntax/Transform/Tactic.lean
+++ b/Mathport/Syntax/Transform/Tactic.lean
@@ -19,6 +19,8 @@ def transformConsecutiveTactics : Syntax → Syntax → M Syntax
     `(tactic| have $[$id:ident]? $[: $ty:term]? := $t)
   | `(tactic| let $id:ident $[: $ty:term]?), `(tactic|· $[$tacs:tactic $[;]?]*) =>
     `(tactic| let $id:ident $[: $ty:term]? := by $[$tacs:tactic]*)
+  | `(tactic| let $[: $ty:term]?), `(tactic|· $[$tacs:tactic $[;]?]*) =>
+    `(tactic| let this $[: $ty:term]? := by $[$tacs:tactic]*)
   | `(tactic| obtain $[$pat]? $[: $ty]?), `(tactic|· $[$tacs:tactic $[;]?]*) =>
     `(tactic| obtain $[$pat]? $[: $ty]? := by $[$tacs:tactic]*)
   | _, _ => throwUnsupported

--- a/Mathport/Syntax/Translate/Parser.lean
+++ b/Mathport/Syntax/Translate/Parser.lean
@@ -105,6 +105,8 @@ def optPExprList := listOf pExpr <|> pure #[]
 def pExprListOrTExpr := maybeListOf pExpr
 def onlyFlag := (tk "only" *> pure true) <|> pure false
 
+def optTk (yes : Bool) : Option Syntax := if yes then some default else none
+
 def parseBinders : ParserM Binders := do let ⟨_, VMCall.binders bis⟩ ← next | failure; pure bis
 
 def inductiveDecl : ParserM InductiveCmd := do

--- a/Mathport/Syntax/Translate/Tactic/Mathlib/Cache.lean
+++ b/Mathport/Syntax/Translate/Tactic/Mathlib/Cache.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Mathport.Syntax.Translate.Tactic.Basic
+import Mathport.Syntax.Translate.Tactic.Mathlib.Interactive
 
 open Lean
 open Lean.Elab.Tactic (Location)
@@ -13,49 +13,12 @@ open AST3 Parser
 
 -- # tactic.cache
 
-@[trTactic unfreezingI] def trUnfreezingI : TacM Syntax := do
-  `(tactic| ($(← trBlock (← itactic)):tacticSeq))
-
-@[trTactic resetI] def trResetI : TacM Syntax := `(tactic| skip)
-
-@[trTactic substI] def trSubstI : TacM Syntax := do
-  `(tactic| subst $(← trExpr (← parse pExpr)))
-
-def trWithIdentList : Array BinderName → Option (Array Syntax)
-  | #[] => none
-  | ids => some (ids.map trBinderIdent)
-
-@[trTactic casesI] def trCasesI : TacM Syntax := do
-  let (hp, e) ← parse casesArg
-  `(tactic| cases' $[$(hp.map mkIdent) :]?
-    $(← trExpr e) $[with $(trWithIdentList (← parse withIdentList))*]?)
-
-@[trTactic introI] def trIntroI : TacM Syntax := do
-  match ← parse ident_ ? with
-  | some (BinderName.ident h) => `(tactic| intro $(mkIdent h):ident)
-  | _ => `(tactic| intro)
-
-@[trTactic introsI] def trIntrosI : TacM Syntax := do
-  match ← parse ident_* with
-  | #[] => `(tactic| intros)
-  | hs => `(tactic| intros $(hs.map trIdent_)*)
-
-@[trTactic haveI] def trHaveI : TacM Syntax := do
-  let h := (← parse (ident)?).map mkIdent
-  let ty ← (← parse (tk ":" *> pExpr)?).mapM (trExpr ·)
-  match ← parse (tk ":=" *> pExpr)? with
-  | some pr => `(tactic| have $[$h:ident]? $[: $ty:term]? := $(← trExpr pr))
-  | none => `(tactic| have $[$h:ident]? $[: $ty:term]?)
-
-@[trTactic letI] def trLetI : TacM Syntax := do
-  let h ← parse (ident)?
-  let ty ← (← parse (tk ":" *> pExpr)?).mapM (trExpr ·)
-  match ← parse (tk ":=" *> pExpr)? with
-  | some pr =>
-    -- FIXME: this is a keyword now
-    `(tactic| let $(mkIdent <| h.getD `this') $[: $ty:term]? := $(← trExpr pr))
-  | none =>
-    `(tactic| let $[$(h.map mkIdent):ident]? $[: $ty:term]?)
-
-@[trTactic exactI] def trExactI : TacM Syntax := do
-  `(tactic| exact $(← trExpr (← parse pExpr)))
+attribute [trTactic unfreezingI] trId
+attribute [trTactic resetI] trSkip
+attribute [trTactic substI] trSubst
+attribute [trTactic casesI] trCases
+attribute [trTactic introI] trIntro
+attribute [trTactic introsI] trIntros
+attribute [trTactic haveI] trHave
+attribute [trTactic letI] trLet
+attribute [trTactic exactI] trExact

--- a/Mathport/Syntax/Translate/Tactic/Mathlib/Finish.lean
+++ b/Mathport/Syntax/Translate/Tactic/Mathlib/Finish.lean
@@ -19,19 +19,19 @@ def trUsingList (args : Array (Spanned AST3.Expr)) : M Syntax :=
   | args => return #[mkAtom "using", (mkAtom ",").mkSep $ ← args.mapM trExpr]
 
 @[trTactic clarify] def trClarify : TacM Syntax := do
-  let hs := trSimpList (← trSimpArgs (← parse simpArgList))
-  let ps ← trUsingList $ (← parse (tk "using" *> pExprListOrTExpr)?).getD #[]
+  let hs := (← trSimpArgs (← parse simpArgList)).asNonempty
+  let ps := (← (← parse (tk "using" *> pExprListOrTExpr)?).getD #[] |>.mapM (trExpr ·)).asNonempty
   let cfg ← liftM $ (← expr?).mapM trExpr
-  pure $ mkNode ``Parser.Tactic.clarify #[mkAtom "clarify", ← mkConfigStx cfg, hs, ps]
+  `(tactic| clarify $[(config := $cfg)]? $[[$hs,*]]? $[using $ps,*]?)
 
 @[trTactic safe] def trSafe : TacM Syntax := do
-  let hs := trSimpList (← trSimpArgs (← parse simpArgList))
-  let ps ← trUsingList $ (← parse (tk "using" *> pExprListOrTExpr)?).getD #[]
+  let hs := (← trSimpArgs (← parse simpArgList)).asNonempty
+  let ps := (← (← parse (tk "using" *> pExprListOrTExpr)?).getD #[] |>.mapM (trExpr ·)).asNonempty
   let cfg ← liftM $ (← expr?).mapM trExpr
-  pure $ mkNode ``Parser.Tactic.safe #[mkAtom "safe", ← mkConfigStx cfg, hs, ps]
+  `(tactic| safe $[(config := $cfg)]? $[[$hs,*]]? $[using $ps,*]?)
 
 @[trTactic finish] def trFinish : TacM Syntax := do
-  let hs := trSimpList (← trSimpArgs (← parse simpArgList))
-  let ps ← trUsingList $ (← parse (tk "using" *> pExprListOrTExpr)?).getD #[]
+  let hs := (← trSimpArgs (← parse simpArgList)).asNonempty
+  let ps := (← (← parse (tk "using" *> pExprListOrTExpr)?).getD #[] |>.mapM (trExpr ·)).asNonempty
   let cfg ← liftM $ (← expr?).mapM trExpr
-  pure $ mkNode ``Parser.Tactic.finish #[mkAtom "finish", ← mkConfigStx cfg, hs, ps]
+  `(tactic| finish $[(config := $cfg)]? $[[$hs,*]]? $[using $ps,*]?)

--- a/Mathport/Syntax/Translate/Tactic/Mathlib/Misc1.lean
+++ b/Mathport/Syntax/Translate/Tactic/Mathlib/Misc1.lean
@@ -215,10 +215,10 @@ open AST3 Parser
   let hs := (← trSimpArgs (← parse simpArgList)).asNonempty
   let attrs := (← parse (tk "with" *> ident*)?).getD #[] |>.map mkIdent |>.asNonempty
   let e ← liftM $ (← parse (tk "using" *> pExpr)?).mapM trExpr
-  let (cfg, disch) ← parseSimpConfigCore (← expr?)
+  let (cfg, disch) ← parseSimpConfig (← expr?)
+  let cfg ← mkConfigStx? (cfg.bind quoteSimpConfig)
   let rest ← `(Mathlib.Tactic.simpaArgsRest|
-    $[(config := $(cfg.bind quoteSimpConfig))]? $[(disch := $disch:tactic)]?
-    $[only%$o]? $[[$hs,*]]? $[with $attrs*]? $[using $e]?)
+    $[$cfg:config]? $(disch)? $[only%$o]? $[[$hs,*]]? $[with $attrs*]? $[using $e]?)
   match unfold, squeeze with
   | none, none => `(tactic| simpa $rest)
   | none, some _ => `(tactic| simpa? $rest)

--- a/Mathport/Syntax/Translate/Tactic/Mathlib/Misc1.lean
+++ b/Mathport/Syntax/Translate/Tactic/Mathlib/Misc1.lean
@@ -90,7 +90,7 @@ open AST3 Parser
   `(tactic| lift $(← trExpr (← parse pExpr))
     to $(← trExpr (← parse (tk "to" *> pExpr)))
     $[using $(← liftM $ (← parse (tk "using" *> pExpr)?).mapM trExpr)]?
-    $[with $(trWithIdentList (← parse withIdentList))*]?)
+    $[with $(((← parse withIdentList).map trBinderIdent).asNonempty)*]?)
 
 -- # tactic.lift
 
@@ -189,44 +189,46 @@ open AST3 Parser
 @[trUserCmd «#simp»] def trSimpCmd : TacM Syntax := do
   let (o, args, attrs, e) ← parse $
     return (← onlyFlag, ← simpArgList, (← (tk "with" *> ident*)?).getD #[], ← (tk ":")? *> pExpr)
-  let hs := trSimpList (← trSimpArgs args)
-  let o := if o then mkNullNode #[mkAtom "only"] else mkNullNode
-  let colon := if attrs.isEmpty then mkNullNode else mkNullNode #[mkAtom ":"]
-  pure $ mkNode ``Parser.Command.simp #[mkAtom "#simp",
-    o, hs, trSimpAttrs attrs, colon, ← trExpr e]
+  let o := optTk o
+  let hs := (← trSimpArgs args).asNonempty
+  let colon := optTk !attrs.isEmpty
+  let attrs := attrs.map mkIdent |>.asNonempty
+  `(command| #simp $[only%$o]? $[[$hs,*]]? $[with $attrs*]? $[:%$colon]? $(← trExpr e))
 
 -- # tactic.simp_result
 @[trTactic dsimp_result] def trDSimpResult : TacM Syntax := do
-  let o := if ← parse onlyFlag then mkNullNode #[mkAtom "only"] else mkNullNode
-  let hs := trSimpList (← trSimpArgs (← parse simpArgList))
-  pure $ mkNode ``Parser.Tactic.dsimpResult #[mkAtom "dsimp_result", o, hs,
-    trSimpAttrs $ (← parse (tk "with" *> ident*)?).getD #[],
-    mkAtom "=>", ← trBlock (← itactic)]
+  let o := optTk (← parse onlyFlag)
+  let hs := (← trSimpArgs (← parse simpArgList)).asNonempty
+  let attrs := (← parse (tk "with" *> ident*)?).getD #[] |>.map mkIdent |>.asNonempty
+  `(tactic| dsimp_result $[only%$o]? $[[$hs,*]]? $[with $attrs*]? => $(← trBlock (← itactic)))
 
 @[trTactic simp_result] def trSimpResult : TacM Syntax := do
-  let o := if ← parse onlyFlag then mkNullNode #[mkAtom "only"] else mkNullNode
-  let hs := trSimpList (← trSimpArgs (← parse simpArgList))
-  pure $ mkNode ``Parser.Tactic.simpResult #[mkAtom "simp_result", o, hs,
-    trSimpAttrs $ (← parse (tk "with" *> ident*)?).getD #[],
-    mkAtom "=>", ← trBlock (← itactic)]
+  let o := optTk (← parse onlyFlag)
+  let hs := (← trSimpArgs (← parse simpArgList)).asNonempty
+  let attrs := (← parse (tk "with" *> ident*)?).getD #[] |>.map mkIdent |>.asNonempty
+  `(tactic| simp_result $[only%$o]? $[[$hs,*]]? $[with $attrs*]? => $(← trBlock (← itactic)))
 
 -- # tactic.simpa
 @[trTactic simpa] def trSimpa : TacM Syntax := do
-  let unfold := (← parse (tk "!")?).map fun _ => default
-  let squeeze := (← parse (tk "?")?).map fun _ => default
-  let o := if ← parse onlyFlag then some default else none
-  let hs := some (← trSimpArgs (← parse simpArgList)) |>.filter (!·.isEmpty)
-  let attrs := (← parse (tk "with" *> ident*)?).map (·.map mkIdent)
+  let unfold ← parse (tk "!")?; let squeeze ← parse (tk "?")?
+  let o := optTk (← parse onlyFlag)
+  let hs := (← trSimpArgs (← parse simpArgList)).asNonempty
+  let attrs := (← parse (tk "with" *> ident*)?).getD #[] |>.map mkIdent |>.asNonempty
   let e ← liftM $ (← parse (tk "using" *> pExpr)?).mapM trExpr
   let (cfg, disch) ← parseSimpConfigCore (← expr?)
-  let cfg := cfg.bind quoteSimpConfig
-  `(tactic| simpa $[!%$unfold]? $[?%$squeeze]? $[(config := $cfg)]? $[(disch := $disch:tactic)]?
-      $[only%$o]? $[[$hs,*]]? $[with $attrs*]? $[using $e]?)
+  let rest ← `(Mathlib.Tactic.simpaArgsRest|
+    $[(config := $(cfg.bind quoteSimpConfig))]? $[(disch := $disch:tactic)]?
+    $[only%$o]? $[[$hs,*]]? $[with $attrs*]? $[using $e]?)
+  match unfold, squeeze with
+  | none, none => `(tactic| simpa $rest)
+  | none, some _ => `(tactic| simpa? $rest)
+  | some _, none => `(tactic| simpa! $rest)
+  | some _, some _ => `(tactic| simpa!? $rest)
 
 -- # tactic.split_ifs
 @[trTactic split_ifs] def trSplitIfs : TacM Syntax := do
   `(tactic| split_ifs $(← trLoc (← parse location))?
-    $[with $(trWithIdentList (← parse withIdentList))*]?)
+    $[with $(((← parse withIdentList).map trBinderIdent).asNonempty)*]?)
 
 -- # tactic.swap_var
 @[trTactic swap_var] def trSwapVar : TacM Syntax := do
@@ -328,9 +330,7 @@ open AST3 Parser
   let pat ← liftM $ (← parse (tk ":" *> pExpr)?).mapM trExpr
   let cases ← liftM $ (← parse (tk ":=" *> pExpr)?).mapM trExpr
   let perms ← parse (tk "using" *> (listOf ident* <|> return #[← ident*]))?
-  let perms := match perms.getD #[] with
-  | #[] => none
-  | perms => some (perms.map (·.map mkIdent))
+  let perms := (perms.getD #[]).map (·.map mkIdent) |>.asNonempty
   let disch ← liftM $ (← expr?).mapM trExpr
   `(tactic| wlog $[(discharger := $disch)]? $(h)? $[: $pat]? $[:= $cases]? $[using $[$perms*],*]?)
 

--- a/Mathport/Syntax/Translate/Tactic/Mathlib/Misc2.lean
+++ b/Mathport/Syntax/Translate/Tactic/Mathlib/Misc2.lean
@@ -103,10 +103,9 @@ open AST3 Parser
   let hs := (← trSimpArgs (← parse simpArgList)).asNonempty
   let attrs := (← parse (tk "with" *> ident*)?).getD #[] |>.map mkIdent |>.asNonempty
   let loc ← trLoc (← parse location)
-  let (cfg, disch) ← parseSimpConfigCore (← expr?)
+  let (cfg, disch) ← parseSimpConfig (← expr?)
   let cfg ← mkConfigStx? $ cfg.bind quoteSimpConfig
-  `(tactic| field_simp $(cfg)? $[(disch := $disch:tactic)]?
-    $[only%$o]? $[[$hs,*]]? $[with $attrs*]? $(loc)?)
+  `(tactic| field_simp $(cfg)? $(disch)? $[only%$o]? $[[$hs,*]]? $[with $attrs*]? $(loc)?)
 
 -- # tactic.equiv_rw
 

--- a/Mathport/Syntax/Translate/Tactic/Mathlib/Misc2.lean
+++ b/Mathport/Syntax/Translate/Tactic/Mathlib/Misc2.lean
@@ -17,7 +17,7 @@ open AST3 Parser
 -- # tactic.trunc_cases
 @[trTactic trunc_cases] def trTruncCases : TacM Syntax := do
   `(tactic| trunc_cases $(← trExpr (← parse pExpr))
-    $[with $(trWithIdentList (← parse withIdentList))*]?)
+    $[with $(((← parse withIdentList).map trBinderIdent).asNonempty)*]?)
 
 -- # tactic.abel
 @[trTactic abel1] def trAbel1 : TacM Syntax := do
@@ -99,14 +99,14 @@ open AST3 Parser
 
 -- # tactic.field_simp
 @[trTactic field_simp] def trFieldSimp : TacM Syntax := do
-  let o := if ← parse onlyFlag then mkNullNode #[mkAtom "only"] else mkNullNode
-  let hs := trSimpList (← trSimpArgs (← parse simpArgList))
-  let attrs := (← parse (tk "with" *> ident*)?).getD #[]
-  let loc := mkOptionalNode $ ← trLoc (← parse location)
-  let (cfg, disch) ← parseSimpConfig (← expr?)
-  let cfg ← mkConfigStx $ cfg.bind quoteSimpConfig
-  pure $ mkNode ``Parser.Tactic.fieldSimp #[mkAtom "field_simp", cfg, disch,
-    o, hs, trSimpAttrs attrs, loc]
+  let o := optTk (← parse onlyFlag)
+  let hs := (← trSimpArgs (← parse simpArgList)).asNonempty
+  let attrs := (← parse (tk "with" *> ident*)?).getD #[] |>.map mkIdent |>.asNonempty
+  let loc ← trLoc (← parse location)
+  let (cfg, disch) ← parseSimpConfigCore (← expr?)
+  let cfg ← mkConfigStx? $ cfg.bind quoteSimpConfig
+  `(tactic| field_simp $(cfg)? $[(disch := $disch:tactic)]?
+    $[only%$o]? $[[$hs,*]]? $[with $attrs*]? $(loc)?)
 
 -- # tactic.equiv_rw
 
@@ -205,14 +205,13 @@ attribute [trNITactic try_refl_tac] trControlLawsTac
 -- # logic.nontrivial
 @[trTactic nontriviality] def trNontriviality : TacM Syntax := do
   let t ← liftM $ (← parse (pExpr)?).mapM trExpr
-  let lems ← trSimpArgs (← parse (tk "using" *> simpArgList <|> pure #[]))
-  let lems := if lems.isEmpty then none else some lems
+  let lems := (← trSimpArgs (← parse (tk "using" *> simpArgList <|> pure #[]))).asNonempty
   `(tactic| nontriviality $[$t]? $[using $lems,*]?)
 
 -- # order.filter.basic
 @[trTactic filter_upwards] def trFilterUpwards : TacM Syntax := do
-  let s := match ← (← parse pExprList).mapM (trExpr ·) with | #[] => none | s => some s
-  let wth := trWithIdentList (← parse withIdentList)
+  let s := (← (← parse pExprList).mapM (trExpr ·)).asNonempty
+  let wth := (← parse withIdentList).map trBinderIdent |>.asNonempty
   let tgt ← (← parse (tk "using" *> pExpr)?).mapM (trExpr ·)
   `(tactic| filter_upwards $[[$s:term,*]]? $[with $[$wth:term]*]? $[using $tgt:term]?)
 
@@ -228,15 +227,14 @@ attribute [trNITactic try_refl_tac] trControlLawsTac
 @[trTactic mv_bisim] def trMvBisim : TacM Syntax := do
   `(tactic| mv_bisim
     $[$(← liftM $ (← parse (pExpr)?).mapM trExpr)]?
-    $[with $(trWithIdentList (← parse withIdentList))*]?)
+    $[with $(((← parse withIdentList).map trBinderIdent).asNonempty)*]?)
 
 -- # topology.tactic
 
 @[trUserAttr continuity] def trContinuityAttr := tagAttr `continuity
 
 @[trTactic continuity] def trContinuity : TacM Syntax := do
-  let bang ← parse (tk "!")?
-  let ques ← parse (tk "?")?
+  let bang ← parse (tk "!")?; let ques ← parse (tk "?")?
   let cfg ← liftM $ (← expr?).mapM trExpr
   match bang, ques with
   | none, none => `(tactic| continuity $[(config := $cfg)]?)
@@ -263,8 +261,7 @@ attribute [trNITactic try_refl_tac] trControlLawsTac
 @[trUserAttr measurability] def trMeasurabilityAttr := tagAttr `measurability
 
 @[trTactic measurability] def trMeasurability : TacM Syntax := do
-  let bang ← parse (tk "!")?
-  let ques ← parse (tk "?")?
+  let bang ← parse (tk "!")?; let ques ← parse (tk "?")?
   let cfg ← liftM $ (← expr?).mapM trExpr
   match bang, ques with
   | none, none => `(tactic| measurability $[(config := $cfg)]?)

--- a/Mathport/Syntax/Translate/Tactic/Mathlib/NormNum.lean
+++ b/Mathport/Syntax/Translate/Tactic/Mathlib/NormNum.lean
@@ -18,9 +18,9 @@ open Parser
   `(tactic| norm_num1 $(← trLoc (← parse location))?)
 
 @[trTactic norm_num] def trNormNum : TacM Syntax := do
-  let hs := trSimpList (← trSimpArgs (← parse simpArgList))
-  let loc := mkOptionalNode $ ← trLoc (← parse location)
-  pure $ mkNode ``Tactic.normNum #[mkAtom "norm_num", hs, loc]
+  let hs := (← trSimpArgs (← parse simpArgList)).asNonempty
+  let loc ← trLoc (← parse location)
+  `(tactic| norm_num $[[$hs,*]]? $(loc)?)
 
 @[trTactic apply_normed] def trApplyNormed : TacM Syntax := do
   `(tactic| apply_normed $(← trExpr (← parse pExpr)))
@@ -28,5 +28,5 @@ open Parser
 @[trConv norm_num1] def trNormNum1Conv : TacM Syntax := `(conv| norm_num1)
 
 @[trConv norm_num] def trNormNumConv : TacM Syntax := do
-  let hs := trSimpList (← trSimpArgs (← parse simpArgList))
-  pure $ mkNode ``Parser.Tactic.Conv.normNum #[mkAtom "norm_num", hs]
+  let hs := (← trSimpArgs (← parse simpArgList)).asNonempty
+  `(conv| norm_num $[[$hs,*]]?)

--- a/Mathport/Syntax/Translate/Tactic/Mathlib/Padics.lean
+++ b/Mathport/Syntax/Translate/Tactic/Mathlib/Padics.lean
@@ -27,9 +27,8 @@ open Parser
 @[trTactic init_ring] def trInitRing : TacM Syntax := do
   `(tactic| init_ring $[using $(← liftM $ (← parse (tk "using" *> pExpr)?).mapM trExpr)]?)
 
-@[trTactic ghost_simp] def trGhostSimp : TacM Syntax :=
-  return mkNode ``Parser.Tactic.ghostSimp #[mkAtom "ghost_simp",
-    trSimpList (← trSimpArgs (← parse simpArgList))]
+@[trTactic ghost_simp] def trGhostSimp : TacM Syntax := do
+  `(tactic| ghost_simp $[[$((← trSimpArgs (← parse simpArgList)).asNonempty),*]]?)
 
 @[trTactic witt_truncate_fun_tac] def trWittTruncateFunTac : TacM Syntax :=
   `(tactic| witt_truncate_fun_tac)

--- a/Mathport/Syntax/Translate/Tactic/Mathlib/Squeeze.lean
+++ b/Mathport/Syntax/Translate/Tactic/Mathlib/Squeeze.lean
@@ -17,44 +17,49 @@ open Parser
   `(tactic| squeeze_scope $(← trBlock (← itactic)):tacticSeq)
 
 @[trTactic squeeze_simp] def trSqueezeSimp : TacM Syntax := do
-  let (tac, s) := match ← parse_0 $ parse (tk "?")?, ← parse (tk "!")? with
-  | none, none => (``Parser.Tactic.squeezeSimp, "squeeze_simp")
-  | none, some _ => (``Parser.Tactic.squeezeSimp?, "squeeze_simp?")
-  | some _, none => (``Parser.Tactic.squeezeSimp!, "squeeze_simp!")
-  | some _, some _ => (``Parser.Tactic.squeezeSimp?!, "squeeze_simp?!")
-  let o := if ← parse onlyFlag then mkNullNode #[mkAtom "only"] else mkNullNode
-  let hs := trSimpList (← trSimpArgs (← parse simpArgList))
-  let attrs := (← parse (tk "with" *> ident*)?).getD #[]
-  let loc := mkOptionalNode $ ← trLoc (← parse location)
-  let (cfg, disch) ← parseSimpConfig <| (← parse (structInst)?).map Spanned.dummy
-  let cfg ← mkConfigStx $ cfg.bind quoteSimpConfig
-  pure $ mkNode tac #[mkAtom s, cfg, disch, o, hs, trSimpAttrs attrs, loc]
+  let ques ← parse_0 $ parse (tk "?")?; let bang ← parse (tk "!")?
+  let o := optTk (← parse onlyFlag)
+  let hs := (← trSimpArgs (← parse simpArgList)).asNonempty
+  let attrs := (← parse (tk "with" *> ident*)?).getD #[] |>.map mkIdent |>.asNonempty
+  let loc ← trLoc (← parse location)
+  let (cfg, disch) ← parseSimpConfigCore <| (← parse (structInst)?).map Spanned.dummy
+  let rest ← `(Lean.Parser.Tactic.squeezeSimpArgsRest|
+    $[(config := $(cfg.bind quoteSimpConfig))]? $[(disch := $disch:tactic)]?
+    $[only%$o]? $[[$hs,*]]? $[with $attrs*]? $[$loc:location]?)
+  match ques, bang with
+  | none, none => `(tactic| squeeze_simp $rest)
+  | none, some _ => `(tactic| squeeze_simp? $rest)
+  | some _, none => `(tactic| squeeze_simp! $rest)
+  | some _, some _ => `(tactic| squeeze_simp!? $rest)
 
 @[trTactic squeeze_simpa] def trSqueezeSimpa : TacM Syntax := do
-  let (tac, s) := match ← parse_0 $ parse (tk "?")?, ← parse (tk "!")? with
-  | none, none => (``Parser.Tactic.squeezeSimpa, "squeeze_simpa")
-  | none, some _ => (``Parser.Tactic.squeezeSimpa?, "squeeze_simpa?")
-  | some _, none => (``Parser.Tactic.squeezeSimpa!, "squeeze_simpa!")
-  | some _, some _ => (``Parser.Tactic.squeezeSimpa?!, "squeeze_simpa?!")
-  let o := if ← parse onlyFlag then mkNullNode #[mkAtom "only"] else mkNullNode
-  let hs := trSimpList (← trSimpArgs (← parse simpArgList))
-  let attrs := (← parse (tk "with" *> ident*)?).getD #[]
+  let ques ← parse_0 $ parse (tk "?")?; let bang ← parse (tk "!")?
+  let o := optTk (← parse onlyFlag)
+  let hs := (← trSimpArgs (← parse simpArgList)).asNonempty
+  let attrs := (← parse (tk "with" *> ident*)?).getD #[] |>.map mkIdent |>.asNonempty
   let e ← liftM $ (← parse (tk "using" *> pExpr)?).mapM trExpr
-  let (cfg, disch) ← parseSimpConfig <| (← parse (structInst)?).map Spanned.dummy
-  let cfg ← mkConfigStx $ cfg.bind quoteSimpConfig
-  pure $ mkNode tac #[mkAtom s, cfg, disch, o, hs, trSimpAttrs attrs,
-    mkOptionalNode' e fun e => #[mkAtom "using", e]]
+  let (cfg, disch) ← parseSimpConfigCore <| (← parse (structInst)?).map Spanned.dummy
+  let rest ← `(Mathlib.Tactic.simpaArgsRest|
+    $[(config := $(cfg.bind quoteSimpConfig))]? $[(disch := $disch:tactic)]?
+    $[only%$o]? $[[$hs,*]]? $[with $attrs*]? $[using $e]?)
+  match ques, bang with
+  | none, none => `(tactic| squeeze_simpa $rest)
+  | none, some _ => `(tactic| squeeze_simpa? $rest)
+  | some _, none => `(tactic| squeeze_simpa! $rest)
+  | some _, some _ => `(tactic| squeeze_simpa!? $rest)
 
 @[trTactic squeeze_dsimp] def trSqueezeDSimp : TacM Syntax := do
-  let (tac, s) := match ← parse_0 $ parse (tk "?")?, ← parse (tk "!")? with
-  | none, none => (``Parser.Tactic.squeezeDSimp, "squeeze_dsimp")
-  | none, some _ => (``Parser.Tactic.squeezeDSimp?, "squeeze_dsimp?")
-  | some _, none => (``Parser.Tactic.squeezeDSimp!, "squeeze_dsimp!")
-  | some _, some _ => (``Parser.Tactic.squeezeDSimp?!, "squeeze_dsimp?!")
-  let o := if ← parse onlyFlag then mkNullNode #[mkAtom "only"] else mkNullNode
-  let hs := trSimpList (← trSimpArgs (← parse simpArgList))
-  let attrs := (← parse (tk "with" *> ident*)?).getD #[]
-  let loc := mkOptionalNode $ ← trLoc (← parse location)
-  let (cfg, _) ← parseSimpConfig <| (← parse (structInst)?).map Spanned.dummy
-  let cfg ← mkConfigStx $ cfg.bind quoteSimpConfig
-  pure $ mkNode tac #[mkAtom s, cfg, o, hs, trSimpAttrs attrs, loc]
+  let ques ← parse_0 $ parse (tk "?")?; let bang ← parse (tk "!")?
+  let o := optTk (← parse onlyFlag)
+  let hs := (← trSimpArgs (← parse simpArgList)).asNonempty
+  let attrs := (← parse (tk "with" *> ident*)?).getD #[] |>.map mkIdent |>.asNonempty
+  let loc ← trLoc (← parse location)
+  let (cfg, _) ← parseSimpConfigCore <| (← parse (structInst)?).map Spanned.dummy
+  let rest ← `(Lean.Parser.Tactic.squeezeDSimpArgsRest|
+    $[(config := $(cfg.bind quoteSimpConfig))]?
+    $[only%$o]? $[[$hs,*]]? $[with $attrs*]? $[$loc:location]?)
+  match ques, bang with
+  | none, none => `(tactic| squeeze_dsimp $rest)
+  | none, some _ => `(tactic| squeeze_dsimp? $rest)
+  | some _, none => `(tactic| squeeze_dsimp! $rest)
+  | some _, some _ => `(tactic| squeeze_dsimp!? $rest)

--- a/Mathport/Syntax/Translate/Tactic/Mathlib/Squeeze.lean
+++ b/Mathport/Syntax/Translate/Tactic/Mathlib/Squeeze.lean
@@ -22,10 +22,10 @@ open Parser
   let hs := (← trSimpArgs (← parse simpArgList)).asNonempty
   let attrs := (← parse (tk "with" *> ident*)?).getD #[] |>.map mkIdent |>.asNonempty
   let loc ← trLoc (← parse location)
-  let (cfg, disch) ← parseSimpConfigCore <| (← parse (structInst)?).map Spanned.dummy
+  let (cfg, disch) ← parseSimpConfig <| (← parse (structInst)?).map Spanned.dummy
+  let cfg ← mkConfigStx? $ cfg.bind quoteSimpConfig
   let rest ← `(Lean.Parser.Tactic.squeezeSimpArgsRest|
-    $[(config := $(cfg.bind quoteSimpConfig))]? $[(disch := $disch:tactic)]?
-    $[only%$o]? $[[$hs,*]]? $[with $attrs*]? $[$loc:location]?)
+    $[$cfg:config]? $(disch)? $[only%$o]? $[[$hs,*]]? $[with $attrs*]? $[$loc:location]?)
   match ques, bang with
   | none, none => `(tactic| squeeze_simp $rest)
   | none, some _ => `(tactic| squeeze_simp? $rest)
@@ -38,10 +38,10 @@ open Parser
   let hs := (← trSimpArgs (← parse simpArgList)).asNonempty
   let attrs := (← parse (tk "with" *> ident*)?).getD #[] |>.map mkIdent |>.asNonempty
   let e ← liftM $ (← parse (tk "using" *> pExpr)?).mapM trExpr
-  let (cfg, disch) ← parseSimpConfigCore <| (← parse (structInst)?).map Spanned.dummy
+  let (cfg, disch) ← parseSimpConfig <| (← parse (structInst)?).map Spanned.dummy
+  let cfg ← mkConfigStx? $ cfg.bind quoteSimpConfig
   let rest ← `(Mathlib.Tactic.simpaArgsRest|
-    $[(config := $(cfg.bind quoteSimpConfig))]? $[(disch := $disch:tactic)]?
-    $[only%$o]? $[[$hs,*]]? $[with $attrs*]? $[using $e]?)
+    $[$cfg:config]? $(disch)? $[only%$o]? $[[$hs,*]]? $[with $attrs*]? $[using $e]?)
   match ques, bang with
   | none, none => `(tactic| squeeze_simpa $rest)
   | none, some _ => `(tactic| squeeze_simpa? $rest)
@@ -54,10 +54,10 @@ open Parser
   let hs := (← trSimpArgs (← parse simpArgList)).asNonempty
   let attrs := (← parse (tk "with" *> ident*)?).getD #[] |>.map mkIdent |>.asNonempty
   let loc ← trLoc (← parse location)
-  let (cfg, _) ← parseSimpConfigCore <| (← parse (structInst)?).map Spanned.dummy
+  let (cfg, _) ← parseSimpConfig <| (← parse (structInst)?).map Spanned.dummy
+  let cfg ← mkConfigStx? $ cfg.bind quoteSimpConfig
   let rest ← `(Lean.Parser.Tactic.squeezeDSimpArgsRest|
-    $[(config := $(cfg.bind quoteSimpConfig))]?
-    $[only%$o]? $[[$hs,*]]? $[with $attrs*]? $[$loc:location]?)
+    $[$cfg:config]? $[only%$o]? $[[$hs,*]]? $[with $attrs*]? $[$loc:location]?)
   match ques, bang with
   | none, none => `(tactic| squeeze_dsimp $rest)
   | none, some _ => `(tactic| squeeze_dsimp? $rest)

--- a/Mathport/Util/Misc.lean
+++ b/Mathport/Util/Misc.lean
@@ -130,6 +130,10 @@ def List.splitAt' {α} (xs : List α) (i : Nat) : List α × List α :=
 def Array.splitAt {α} (xs : Array α) (i : Nat) : Array α × Array α :=
   ((xs.toList.take i).toArray, (xs.toList.drop i).toArray)
 
+def Array.asNonempty : Array α → Option (Array α)
+  | #[] => none
+  | hs => some hs
+
 -- TODO: faster version
 def Std.HashMap.insertWith [Hashable α] [BEq α] (m : HashMap α β) (merge : β → β → β) (a : α) (b : β) : HashMap α β :=
   match m.find? a with

--- a/Mathport/Util/String.lean
+++ b/Mathport/Util/String.lean
@@ -24,10 +24,10 @@ inductive CapsKind
   | pascal
 
 def getCapsKind (snake : String) : CapsKind := Id.run do
-  let mut s := snake
-  let startPos := if s.startsWith "_" then 1 else 0
-  let stopPos  := if s.endsWith "_" then s.length - 1 else s.length
-  s := Substring.mk s startPos stopPos |>.toString
+  let s := snake
+  let startPos := if s.startsWith "_" then ⟨1⟩ else 0
+  let stopPos  := if s.endsWith "_" then s.endPos - ⟨1⟩ else s.endPos
+  let s := Substring.mk s startPos stopPos
   if s.contains '_' then CapsKind.snake
   else if s.front == s.front.toLower then CapsKind.camel
   else CapsKind.pascal

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -9,7 +9,7 @@ package mathport {
     -- as changes to tactics in mathlib4 may cause breakages here.
     -- Please ensure that `lean-toolchain` points to the same release of Lean 4
     -- as this commit of mathlib4 uses.
-    src := Source.git "https://github.com/leanprover-community/mathlib4.git" "809d064846c4171b3bdf358b067c4211baa4e236"
+    src := Source.git "https://github.com/leanprover-community/mathlib4.git" "b59f265dafebcca990e5710ae008691a4b549ea6"
   }],
   binRoot := `MathportApp
   moreLinkArgs := if Platform.isWindows then #[] else #["-rdynamic"]

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2022-03-17
+leanprover/lean4:nightly-2022-03-21


### PR DESCRIPTION
Sebastian's trick for interpolating optional tokens like `$[only%$o]` fixed a blocker for many syntax quotations here, so I took the opportunity to upgrade many tactics to use syntax quotations.

* Fixed a few cases of `String.Pos <-> Nat` conversions
* Fixed uses of `this` as an identifier in `have` and `let`
* Added `Array.asNonempty` which is really useful
* All of the `haveI`etc tactics are aliases of other tactics now, so avoid duplication
* `subst` supports a term now
