### PR TITLE
fix: update elan URL

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -27,7 +27,7 @@ ENTRYPOINT ["/bin/bash", "-l"]
 ENV PATH="/home/lean/.elan/bin:/home/lean/.local/bin:$PATH"
 
 # install elan
-RUN curl https://raw.githubusercontent.com/Kha/elan/master/elan-init.sh -sSf | sh -s -- -y && \
+RUN curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y && \
     . ~/.profile && \
     elan toolchain uninstall stable
 


### PR DESCRIPTION
This outdated URL was breaking CI in mathlib earlier today.