### PR TITLE
Split CI into predata and mathport

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
       - 'staging*.tmp'
   # pull_request:
 
-name: ci
+name: mathport
 
 jobs:
   # Cancels previous runs of jobs in this file
@@ -22,7 +22,7 @@ jobs:
           access_token: ${{ github.token }}
 
   build:
-    name: Build
+    name: Mathport
     runs-on: mathport
     steps:
       - name: clean up working directory
@@ -40,31 +40,31 @@ jobs:
 
       - uses: actions/checkout@v2
 
+      - name: install jq
+        run: |
+          curl -sSfL https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 >~/.elan/bin/jq
+          chmod +x ~/.elan/bin/jq
+      - name: download predata
+        run: |
+          TAG=$(./latest-predata-release.sh)
+          ./download-predata.sh $TAG
+          mkdir -p Outputs/oleans/leanbin Outputs/oleans/mathbin
+          echo $TAG > Outputs/oleans/leanbin/predata-tag
+          echo $TAG > Outputs/oleans/mathbin/predata-tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: build mathport
         run: make build
 
-      - name: prepare sources
-        run: make mathbin-source lean3-source
-
-      - name: prepare predata for Lean 3
-        run: make lean3-predata
-
       - name: run mathport on Lean 3
         run: env time -v make port-lean
-
-      - name: prepare predata for mathlib
-        run: make mathbin-predata
-
-      - name: clean up a bit
-        run: |
-          rm -rf sources/lean/.git sources/mathlib/.git
-          find sources -name "*.olean" -delete
 
       - name: run mathport on mathlib
         run: env time -v make port-mathbin
 
       - name: prepare tarballs for release
-        run: make tarballs
+        run: make mathport-tarballs
 
       - name: set tag (non-master)
         if: github.ref != 'refs/heads/master'
@@ -82,10 +82,8 @@ jobs:
           tag_name: ${{ env.TAG }}-${{ env.SHORT_SHA }}
           target_commitish: ${{ github.sha }}
           files: |
-            lean3-predata.tar.gz
             lean3-binport.tar.gz
             lean3-synport.tar.gz
-            mathlib3-predata.tar.gz
             mathlib3-binport.tar.gz
             mathlib3-synport.tar.gz
         env:
@@ -99,10 +97,8 @@ jobs:
           tag_name: ${{ env.TAG }}
           target_commitish: ${{ github.sha }}
           files: |
-            lean3-predata.tar.gz
             lean3-binport.tar.gz
             lean3-synport.tar.gz
-            mathlib3-predata.tar.gz
             mathlib3-binport.tar.gz
             mathlib3-synport.tar.gz
         env:

--- a/.github/workflows/predata.yml
+++ b/.github/workflows/predata.yml
@@ -1,0 +1,70 @@
+on:
+  # push:
+  #   branches-ignore:
+  #     # ignore tmp branches used by bors
+  #     - 'staging.tmp*'
+  #     - 'trying.tmp*'
+  #     - 'staging*.tmp'
+  schedule:
+    - cron: '0 7 * * *'  # 8AM CET/11PM PT
+
+name: predata
+
+jobs:
+  predata:
+    if: github.repository == 'leanprover-community/mathport'
+    name: Predata
+    runs-on: mathport
+    steps:
+      - name: clean up working directory
+        run: rm -rf *
+
+      - name: clean up elan
+        run: rm -rf $HOME/.elan
+
+      - name: install elan
+        run: |
+          set -o pipefail
+          curl -sSfL https://github.com/leanprover/elan/releases/download/v1.3.1/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
+          ./elan-init -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> $GITHUB_PATH
+
+      - uses: actions/checkout@v2
+
+      - name: prepare sources
+        run: make mathbin-source lean3-source
+
+      - name: prepare predata for Lean 3
+        run: make lean3-predata
+
+      - name: prepare predata for mathlib
+        run: make mathbin-predata
+
+      - name: clean up a bit
+        run: |
+          rm -rf sources/lean/.git sources/mathlib/.git
+          find sources -name "*.olean" -delete
+
+      - name: prepare tarballs for release
+        run: make predata-tarballs
+
+      - name: set tag
+        run: echo "TAG=predata-nightly-$(date -u +%F)" >> $GITHUB_ENV
+
+      - name: release (master)
+        uses: softprops/action-gh-release@v1
+        with:
+          prerelease: true
+          tag_name: ${{ env.TAG }}
+          target_commitish: ${{ github.sha }}
+          files: |
+            lean3-predata.tar.gz
+            mathlib3-predata.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUSH_NIGHTLY_TOKEN }}
+
+      - name: clean up working directory
+        run: rm -rf *
+
+      - name: clean up elan
+        run: rm -rf $HOME/.elan

--- a/Makefile
+++ b/Makefile
@@ -114,14 +114,18 @@ test-import-leanbin:
 test-import-mathbin:
 	cd Test/importMathbin && rm -rf build lean_packages && lake build
 
-tarballs:
-	mkdir -p Outputs/src/leanbin Outputs/src/mathbin Outputs/oleans/leanbin Outputs/oleans/mathbin
+predata-tarballs:
 	find sources/lean/library/ -name "*.ast.json" -o -name "*.tlean" | tar -czvf lean3-predata.tar.gz -T -
+	find sources/mathlib/ -name "*.ast.json" -o -name "*.tlean" | tar -czvf mathlib3-predata.tar.gz -T -
+
+mathport-tarballs:
+	mkdir -p Outputs/src/leanbin Outputs/src/mathbin Outputs/oleans/leanbin Outputs/oleans/mathbin
 	tar -czvf lean3-synport.tar.gz -C Outputs/src/leanbin .
 	tar -czvf lean3-binport.tar.gz -C Outputs/oleans/leanbin .
-	find sources/mathlib/ -name "*.ast.json" -o -name "*.tlean" | tar -czvf mathlib3-predata.tar.gz -T -
 	tar -czvf mathlib3-synport.tar.gz -C Outputs/src/mathbin .
 	tar -czvf mathlib3-binport.tar.gz -C Outputs/oleans/mathbin .
+
+tarballs: predata-tarballs mathport-tarballs
 
 unport:
 	rm -rf Outputs/* Logs/*

--- a/download-ported.sh
+++ b/download-ported.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Script to download artifacts from a release.
+# Usage: `./download-ported.sh nightly-2021-11-30`
+
+RELEASE=$1    # e.g. nightly-2021-11-30
+
+if [ -z "$RELEASE" ]; then
+    echo "Usage: ./download-ported.sh nightly-YYYY-MM-DD"
+    echo "See https://github.com/leanprover-community/mathport/releases for available releases"
+    exit 1
+fi
+
+set -exo pipefail
+
+mkdir -p Outputs/oleans/leanbin/
+pushd Outputs/oleans/leanbin/
+curl -L https://github.com/leanprover-community/mathport/releases/download/$RELEASE/lean3-binport.tar.gz | tar xz
+popd
+
+mkdir -p Outputs/src/leanbin/
+pushd Outputs/src/leanbin/
+curl -L https://github.com/leanprover-community/mathport/releases/download/$RELEASE/lean3-synport.tar.gz | tar xz
+popd
+
+mkdir -p Outputs/oleans/mathbin/
+pushd Outputs/oleans/mathbin/
+curl -L https://github.com/leanprover-community/mathport/releases/download/$RELEASE/mathlib3-binport.tar.gz | tar xz
+popd
+
+mkdir -p Outputs/src/mathbin/
+pushd Outputs/src/mathbin/
+curl -L https://github.com/leanprover-community/mathport/releases/download/$RELEASE/mathlib3-synport.tar.gz | tar xz
+popd

--- a/download-predata.sh
+++ b/download-predata.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Script to download artifacts from a release.
+# Usage: `./download-predata.sh nightly-predata-2021-11-30`
+
+RELEASE=$1    # e.g. nightly-predata-2021-11-30
+
+if [ -z "$RELEASE" ]; then
+    echo "Usage: ./download-predata.sh nightly-predata-YYYY-MM-DD"
+    echo "See https://github.com/leanprover-community/mathport/releases for available releases"
+    exit 1
+fi
+
+set -exo pipefail
+
+curl -L https://github.com/leanprover-community/mathport/releases/download/$RELEASE/lean3-predata.tar.gz | tar xz
+curl -L https://github.com/leanprover-community/mathport/releases/download/$RELEASE/mathlib3-predata.tar.gz | tar xz

--- a/download-release.sh
+++ b/download-release.sh
@@ -12,29 +12,10 @@ fi
 
 set -ex
 
-curl -O -L https://github.com/leanprover-community/mathport/releases/download/$RELEASE/lean3-predata.tar.gz
-tar zxvf lean3-predata.tar.gz; rm lean3-predata.tar.gz
+./download-ported.sh "$RELEASE"
 
-curl -O -L https://github.com/leanprover-community/mathport/releases/download/$RELEASE/lean3-binport.tar.gz
-mkdir -p Outputs/oleans/leanbin/
-mv lean3-binport.tar.gz Outputs/oleans/leanbin/
-(cd Outputs/oleans/leanbin/; tar zxvf lean3-binport.tar.gz; rm lean3-binport.tar.gz)
+if [ -f Outputs/oleans/leanbin/predata-tag ]; then
+  RELEASE="$(cat Outputs/oleans/leanbin/predata-tag)"
+fi
 
-curl -O -L https://github.com/leanprover-community/mathport/releases/download/$RELEASE/lean3-synport.tar.gz
-mkdir -p Outputs/src/leanbin/
-mv lean3-synport.tar.gz Outputs/src/leanbin/
-(cd Outputs/src/leanbin/; tar zxvf lean3-synport.tar.gz; rm lean3-synport.tar.gz)
-
-curl -O -L https://github.com/leanprover-community/mathport/releases/download/$RELEASE/mathlib3-predata.tar.gz
-tar zxvf mathlib3-predata.tar.gz; rm mathlib3-predata.tar.gz
-
-curl -O -L https://github.com/leanprover-community/mathport/releases/download/$RELEASE/mathlib3-binport.tar.gz
-mkdir -p Outputs/oleans/mathbin/
-mv mathlib3-binport.tar.gz Outputs/oleans/mathbin/
-(cd Outputs/oleans/mathbin/; tar zxvf mathlib3-binport.tar.gz; rm mathlib3-binport.tar.gz)
-
-curl -O -L https://github.com/leanprover-community/mathport/releases/download/$RELEASE/mathlib3-synport.tar.gz
-mkdir -p Outputs/src/mathbin/
-mv mathlib3-synport.tar.gz Outputs/src/mathbin/
-(cd Outputs/src/mathbin/; tar zxvf mathlib3-synport.tar.gz; rm mathlib3-synport.tar.gz)
-
+./download-predata.sh "$RELEASE"

--- a/latest-predata-release.sh
+++ b/latest-predata-release.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+if [ -z "$GITHUB_TOKEN" ]; then
+  echo "GITHUB_TOKEN needs to be set"
+  exit 1
+fi
+
+curl -s -H "Authorization: token $GITHUB_TOKEN" \
+    'https://api.github.com/repos/leanprover-community/mathport/releases?per_page=100' \
+  | jq -r '.[].tag_name' \
+  | grep '^predata-nightly' \
+  | head -n1


### PR DESCRIPTION
This is particularly helpful in times like these, when mathport fails and doesn't upload the predata for easy local debugging.

The first commit only adds a workflow that creates predata-only releases (once every day).  Once that works, I'll change the other workflow to use the prebuilt predata.