### PR TITLE
feat: indicate replacements in synport output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,3 +133,9 @@ Outputs/src/oneshot/Oneshot/Main.lean: Oneshot/lean3-in/main.ast.json Oneshot/le
 
 oneshot: Outputs/src/oneshot/Oneshot/Main.lean
 	# output is in Outputs/src/oneshot/Oneshot/Main.lean
+
+clean-oneshot:
+	find Oneshot/lean3-in -name "*.olean" -delete
+	rm Oneshot/lean3-in/main.ast.json || true
+	cd Oneshot/lean4-in && lake clean
+	rm config.oneshot.json || true

--- a/Mathport.lean
+++ b/Mathport.lean
@@ -5,6 +5,7 @@ Authors: Mario Carneiro, Daniel Selsam
 -/
 import Mathport.Binary
 import Mathport.Syntax
+import Mathlib
 
 namespace Mathport
 

--- a/Mathport/Binary/Apply.lean
+++ b/Mathport/Binary/Apply.lean
@@ -97,6 +97,7 @@ def refineAddDecl (decl : Declaration) : BinportM (Declaration × ClashKind) := 
             throw ex
       else throw ex
 
+    modifyEnv fun env => binportTag.ext.addEntry env decl.toName
     println! "[addDecl] END CHECK    {path.mod3} {decl.toName}"
     if shouldGenCodeFor decl then
       println! "[compile] {decl.toName} START"

--- a/Mathport/Bridge/Config.lean
+++ b/Mathport/Bridge/Config.lean
@@ -12,6 +12,20 @@ namespace Mathport
 
 open Lean Lean.Json
 
+/-- Controls the way that translated definitions are displayed
+when a lean 4 definition already exists. -/
+inductive ReplacementStyle where
+  /-- Completely skip the mathport output. Good for pruning an already ported file. -/
+  | skip
+  /-- Show a `#print` command pointing at the lean 4 declaration,
+  and then print the mathport output in a comment. Useful when we want to recover
+  the mathport output without re-running the program in case the alignment is erroneous. -/
+  | comment
+  /-- Ignore existing lean 4 definitions and just print all mathport outputs.
+  Will cause redefinition errors. -/
+  | keep
+  deriving FromJson, Inhabited
+
 structure Config where
   pathConfig         : Path.Config
   baseModules        : Array Name := #[`Mathlib]
@@ -25,6 +39,8 @@ structure Config where
   skipProofs         : Bool := false
   skipDefEq          : Bool := true
   error2warning      : Bool := false
-  deriving FromJson
+  replacementStyle   : ReplacementStyle := .comment
+  deriving FromJson, Inhabited
+
 
 end Mathport

--- a/Mathport/Bridge/Rename.lean
+++ b/Mathport/Bridge/Rename.lean
@@ -40,19 +40,25 @@ def getFieldNameMap (env : Environment) : FieldNameMap :=
 def addPossibleFieldName (n3 n4 : Name) : CoreM Unit := do
   modifyEnv fun env => mathportFieldNameExtension.addEntry env (n3, n4)
 
+export Mathlib.Prelude.Rename (binportTag)
+
 namespace Rename
 
 variable (env : Environment)
 
 -- For both binport and synport
-def resolveIdent? (n3 : Name) (removeX : Bool) (choices : Array Name := #[]) : Option ((String × Name) × Name) :=
+def resolveIdent? (n3 : Name) (removeX : Bool) (choices : Array Name := #[]) :
+    Option ((String × Name) × Name) :=
   if h : choices.size > 0 then
-    getRenameMap env |>.find? choices[0] |>.map fun target => (target, clean' (clipLike target.2 n3))
+    getRenameMap env |>.find? choices[0] |>.map fun target =>
+      (target, clean' (clipLike target.2 n3 choices[0]))
   else
     getRenameMap env |>.find? n3 |>.map fun target => (target, clean' target.2)
 where
-  clipLike target n3 :=
-    componentsToName <| target.components.drop (target.getNumParts - n3.getNumParts)
+  clipLike target n3 orig :=
+    if orig.getNumParts == target.getNumParts then
+      componentsToName <| target.components.drop (target.getNumParts - n3.getNumParts)
+    else target
 
   clean' s := if removeX then clean s else s
 

--- a/Mathport/Syntax.lean
+++ b/Mathport/Syntax.lean
@@ -16,7 +16,7 @@ open Syntax
 def synport1 (config : Config) (path : Path) : CommandElabM Unit := do
   let pcfg := config.pathConfig
   let (ast3, _) ← parseAST3 (path.toLean3 pcfg ".ast.json") false
-  let ⟨fmt, _⟩ ← AST3toData4 ast3 pcfg
+  let ⟨fmt, _⟩ ← AST3toData4 ast3 config
   IO.FS.writeFile (path.toLean4src pcfg) (toString fmt)
 
 open Lean Lean.Elab Lean.Elab.Term Lean.Elab.Tactic

--- a/Mathport/Syntax/Translate.lean
+++ b/Mathport/Syntax/Translate.lean
@@ -22,10 +22,10 @@ namespace Translate
 open AST3
 
 partial def M.run' (m : M α) (notations : Array Notation) (commands : Array Command)
-  (pcfg : Path.Config) : CommandElabM α := do
+    (config : Config) : CommandElabM α := do
   let s ← ST.mkRef {}
   let rec ctx := {
-    pcfg, notations, commands
+    config, notations, commands
     transform := Transform.transform
     trExpr := fun e => trExpr' e ctx s
     trTactic := fun e => trTactic' e ctx s
@@ -34,7 +34,7 @@ partial def M.run' (m : M α) (notations : Array Notation) (commands : Array Com
 
 def M.run (m : M α) (comments : Array Comment) :
     (notations : Array Notation) → (commands : Array Command) →
-    (pcfg : Path.Config) → CommandElabM α :=
+    (config : Config) → CommandElabM α :=
   M.run' $ do
     let tactics ← Tactic.builtinTactics
     let niTactics ← Tactic.builtinNITactics
@@ -70,8 +70,8 @@ def AST3toData4 : AST3 → M Data4
 
 end Translate
 
-def AST3toData4 (ast : AST3) : (pcfg : Path.Config) → CommandElabM Data4 :=
+def AST3toData4 (ast : AST3) : (config : Config) → CommandElabM Data4 :=
   (Translate.AST3toData4 ast).run ast.comments ast.indexed_nota ast.indexed_cmds
 
-def tactic3toSyntax (containingFile : AST3) (tac3 : Spanned AST3.Tactic) : (pcfg : Path.Config) → CommandElabM Syntax.Tactic :=
+def tactic3toSyntax (containingFile : AST3) (tac3 : Spanned AST3.Tactic) : (config : Config) → CommandElabM Syntax.Tactic :=
   (Translate.trTactic tac3).run #[] containingFile.indexed_nota containingFile.indexed_cmds

--- a/Mathport/Syntax/Translate/Notation.lean
+++ b/Mathport/Syntax/Translate/Notation.lean
@@ -8,6 +8,7 @@ import Mathport.Util.Misc
 import Mathlib.Mathport.Syntax
 import Std.Util.ExtendedBinder
 import Mathlib.Init.Set
+import Mathlib.Algebra.Abs
 
 open Lean
 
@@ -99,8 +100,8 @@ def predefinedNotations : NameMap NotationEntry := [
     ("expr % ", binary fun f x => Id.run `($f % $x)),
     ("expr- ", unary fun x => Id.run `(-$x)),
     ("expr ⁻¹", unary fun x => Id.run `($x⁻¹)),
-    ("expr| |", unary fun x => Id.run `(abs $x)), -- TODO: https://github.com/leanprover-community/mathport/issues/73
-    ("expr-[1+ ]", unary fun x => Id.run `(-[1+ $x ])),
+    ("expr| |", unary fun x => Id.run `(|$x|)),
+    ("expr-[1+ ]", unary fun x => open Int in Id.run `(-[$x+1])),
     ("expr ^ ", binary fun f x => Id.run `($f ^ $x)),
     ("expr ∘ ", binary fun f x => Id.run `($f ∘ $x)),
     ("expr <= ", binary fun f x => Id.run `($f ≤ $x)),
@@ -147,9 +148,9 @@ def predefinedNotations : NameMap NotationEntry := [
     ("expr |> ", binary fun x y => Id.run `(Option.rhoare $x $y)),
     ("expr ≟ ", binary fun x y => Id.run `(UnificationConstraint.mk $x $y)),
     ("expr =?= ", binary fun x y => Id.run `(UnificationConstraint.mk $x $y)),
-    ("expr <.> ", binary fun x y => Id.run `(mkStrName $x $y)),
-    ("exprcommand", const <| Id.run `(Tactic Unit)),
-    ("expr =ₐ ", binary fun x y => Id.run `(expr.alpha_eqv $x $y)),
+    ("expr <.> ", binary fun x y => Id.run `(.str $x $y)),
+    ("exprcommand", open Lean.Elab.Tactic in const <| Id.run `(Tactic)),
+    ("expr =ₐ ", binary fun x y => Id.run `($x == $y)),
     ("exprdec_trivial", const <| Id.run `(by decide)),
     ("exprformat! ", unary id),
     ("exprsformat! ", unary id),

--- a/Mathport/Syntax/Translate/Tactic/Basic.lean
+++ b/Mathport/Syntax/Translate/Tactic/Basic.lean
@@ -5,6 +5,7 @@ Authors: Mario Carneiro
 -/
 import Mathport.Syntax.Translate.Basic
 import Mathport.Syntax.Translate.Parser
+import Mathlib.Mathport.Syntax
 
 open Lean
 open Lean.Elab.Tactic (Location)

--- a/Mathport/Syntax/Translate/Tactic/Lean3.lean
+++ b/Mathport/Syntax/Translate/Tactic/Lean3.lean
@@ -114,10 +114,9 @@ def trLoc : (loc : Location) → M (Option (TSyntax ``Parser.Tactic.location))
 @[tr_tactic revert] def trRevert : TacM Syntax := do
   `(tactic| revert $[$((← parse ident*).map mkIdent)]*)
 
-def trRwRule (r : RwRule) : M (TSyntax ``Parser.Tactic.rwRule) :=
-  return mkNode ``Parser.Tactic.rwRule #[
-    mkOptionalNode $ if r.symm then some (mkAtom "←") else none,
-    ← trExpr r.rule]
+def trRwRule (r : RwRule) : M (TSyntax ``Parser.Tactic.rwRule) := do
+  let e ← trExpr r.rule
+  if r.symm then `(Parser.Tactic.rwRule| ← $e) else `(Parser.Tactic.rwRule| $e:term)
 
 def trRwArgs : TacM (Array (TSyntax ``Parser.Tactic.rwRule) × Option (TSyntax ``Parser.Tactic.location)) := do
   let q ← liftM $ (← parse rwRules).mapM trRwRule

--- a/config.json
+++ b/config.json
@@ -62,5 +62,6 @@
     "sorries": [],
     "skipProofs": false,
     "skipDefEq": true,
+    "replacementStyle": "comment",
     "error2warning" : true
 }

--- a/lean_packages/manifest.json
+++ b/lean_packages/manifest.json
@@ -1,7 +1,7 @@
 {"version": 2,
  "packages":
  [{"url": "https://github.com/leanprover-community/mathlib4",
-   "rev": "f92230884352f5bc50025aad337f274ae7e5faaf",
+   "rev": "f8373eb4b6d48950c16d4997f32cd8031940b9bc",
    "name": "mathlib",
    "inputRev": "master"},
   {"url": "https://github.com/leanprover/std4",


### PR DESCRIPTION
Definitions that align are now printed like so:
```lean
#print Function.injective_id /-
theorem injective_id : Injective (@id α) := fun a₁ a₂ h => h
-/
```
The comment is the output mathport would have produced, if the definition `Function.injective_id` had not already existed in the environment. This is intended to make it easier to survey an already ported file and quickly identify any new definitions that have been introduced.