### PR TITLE
feat: add `redundantAlign` option

### DIFF
--- a/Mathport/Bridge/Config.lean
+++ b/Mathport/Bridge/Config.lean
@@ -40,6 +40,7 @@ structure Config where
   skipDefEq          : Bool := true
   error2warning      : Bool := false
   replacementStyle   : ReplacementStyle := .comment
+  redundantAlign     : Bool := true
   deriving FromJson, Inhabited
 
 

--- a/Mathport/Syntax/Translate/Command.lean
+++ b/Mathport/Syntax/Translate/Command.lean
@@ -242,6 +242,8 @@ def trDeclId (n : Name) (us : LevelDecl) : M (Option Name × TSyntax ``Parser.Co
   let us := us.map $ Array.map fun u => mkIdent u.kind
   let orig := (← get).current.curNamespace ++ n
   let ((dubious, n4), id) ← renameIdentCore n #[orig]
+  if (← read).config.redundantAlign then
+    pushAlign orig n4
   let (n3, _) := Rename.getClashes (← getEnv) n4
   let mut msg := Format.nil
   let mut found := none

--- a/config.json
+++ b/config.json
@@ -63,5 +63,6 @@
     "skipProofs": false,
     "skipDefEq": true,
     "replacementStyle": "comment",
+    "redundantAlign": true,
     "error2warning" : true
 }


### PR DESCRIPTION
This implements the option discussed in yesterday's mathport meeting. When the `redundantAlign` config option is set to true (the default), mathport will add a "redundant" `#align` line after every declaration, as a base for modification for when you actually do want an `#align`.

cc: @semorrison @pechersky @gebner 