### PR TITLE
feat: add support for block transforms

### DIFF
--- a/Mathport/Binary/ParseTLean.lean
+++ b/Mathport/Binary/ParseTLean.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Daniel Selsam, Gabriel Ebner
 -/
 import Lean
+import Std.Data.List.Basic
 import Mathport.Util.Parse
 import Mathport.Binary.Basic
 import Mathport.Binary.EnvModification
@@ -154,7 +155,7 @@ def parseLine (line : String) : ParseM Unit := do
 
       | ("#IND" :: nps :: n :: t :: nis :: rest) =>
         let (nps, n, t, nis) := (← parseNat nps, ← str2name n, ← str2expr t, ← parseNat nis)
-        let (is, ups) := rest.splitAt' (2 * nis)
+        let (is, ups) := rest.splitAt (2 * nis)
         let lparams ← ups.mapM str2name
         let ctors ← parseIntros is
         modify fun s => { s with ind2params := s.ind2params.insert n nps }

--- a/Mathport/Syntax/Translate/Tactic/Mathlib/Interactive.lean
+++ b/Mathport/Syntax/Translate/Tactic/Mathlib/Interactive.lean
@@ -29,7 +29,7 @@ open AST3 Mathport.Translate.Parser
 @[tr_tactic unfold_aux] def trUnfoldAux : TacM Syntax.Tactic := `(tactic| unfold_aux)
 
 @[tr_tactic recover] def trRecover : TacM Syntax.Tactic :=
-  warn! "unsupported: recover tactic (now a combinator)"
+  return mkBlockTransform fun args => `(tactic| recover $args*)
 
 @[tr_tactic «continue»] def trContinue : TacM Syntax.Tactic := do
   `(tactic| continue $(← trBlock (← itactic)):tacticSeq)

--- a/Mathport/Util/Misc.lean
+++ b/Mathport/Util/Misc.lean
@@ -126,12 +126,9 @@ elab:max "throw!" interpStr:interpolatedStr(term) : term <= ty => do
   let str ← Elab.liftMacroM <| interpStr.expandInterpolatedStr (← `(String)) (← `(toString))
   Elab.Term.elabTerm (← `(throwError ($head ++ $str : String))) ty
 
--- Note: we add "'" because we want the Mathported version to take priority.
-def List.splitAt' {α} (xs : List α) (i : Nat) : List α × List α :=
-  (xs.take i, xs.drop i)
-
 def Array.splitAt {α} (xs : Array α) (i : Nat) : Array α × Array α :=
-  ((xs.toList.take i).toArray, (xs.toList.drop i).toArray)
+  let right := xs.extract i xs.size
+  (xs.shrink i, right)
 
 def Array.asNonempty : Array α → Option (Array α)
   | #[] => none


### PR DESCRIPTION
This allows for tactics like `recover` and `classical` that have been transformed from regular tactics into block tactics to be able to capture the list of subsequent tactics into the block. (We can't use `Mathport.Syntax.Transform` for this because it's not an adjacent tactic transformation. It's also a mandatory transformation - the result is not well formed if the transformation is not applied - unlike most syntax transforms which are optional.)