### PR TITLE
feat: support `using_well_founded`

### DIFF
--- a/Mathport/Syntax/AST3.lean
+++ b/Mathport/Syntax/AST3.lean
@@ -577,8 +577,9 @@ inductive Command
   | «axiom» : AxiomKind → Modifiers → #Name → LevelDecl → Binders → #Expr → Command
   | «axioms» : AxiomKind → Modifiers → Binders → Command
   | decl : DeclKind → Modifiers → Option #Name →
-    LevelDecl → Binders → (ty : Option #Expr) → #DeclVal → Command
-  | mutualDecl : DeclKind → Modifiers → LevelDecl → Binders → Array (Mutual Arm) → Command
+    LevelDecl → Binders → (ty : Option #Expr) → #DeclVal → (uwf : Option #Expr) → Command
+  | mutualDecl : DeclKind → Modifiers → LevelDecl → Binders → Array (Mutual Arm) →
+    (uwf : Option #Expr) → Command
   | «inductive» : InductiveCmd → Command
   | «structure» («class» : Bool) :
     Modifiers → #Name → LevelDecl → Binders → Array #Parent → (ty : Option #Expr) →
@@ -1048,14 +1049,16 @@ instance : Repr Command where reprPrec c _ := match c with
     repr mods ++ repr ak ++ " " ++ n.kind.toString ++
     repr us ++ repr bis ++ optTy ty
   | Command.axioms ak mods bis => repr mods ++ repr ak ++ "s" ++ repr bis
-  | Command.decl dk mods n us bis ty val =>
+  | Command.decl dk mods n us bis ty val uwf =>
     repr mods ++ (repr dk ++
     (match n with | none => "" | some n => " " ++ n.kind.toString : String) ++
-    repr us ++ repr bis ++ optTy ty).group.nest 2 ++ repr val.kind
-  | Command.mutualDecl dk mods us bis arms =>
+    repr us ++ repr bis ++ optTy ty).group.nest 2 ++ repr val.kind ++
+    (match uwf with | none => "" | some e => "\nusing_well_founded " ++ (repr e).nest 2)
+  | Command.mutualDecl dk mods us bis arms uwf =>
     repr mods ++ repr dk ++ " " ++ repr us ++
     Format.joinSep (arms.toList.map fun m => m.name.kind.toString) ", " ++
-    repr bis ++ Format.join (arms.toList.map (Mutual_repr Arms_repr))
+    repr bis ++ Format.join (arms.toList.map (Mutual_repr Arms_repr)) ++
+    (match uwf with | none => "" | some e => "\nusing_well_founded " ++ (repr e).nest 2)
   | Command.inductive ind => repr ind
   | Command.structure cl mods n us bis exts ty mk flds =>
     repr mods ++ (if cl then "class " else "structure ") ++

--- a/Mathport/Syntax/Parse.lean
+++ b/Mathport/Syntax/Parse.lean
@@ -727,15 +727,16 @@ where
   getVars (args : Array AstId) (f : Modifiers → Binders → Command) : M Command := do
     f (← getModifiers args[0]!) <$> args[1:].toArray.mapM getBinder
 
+  getUWF : AstId → M (Spanned Expr) := withNodeK fun _ _ args => getExpr args[0]!
+
   getDecl (dk) (args : Array AstId) : M Command := do
     let mods ← getModifiers args[0]!
     if args[1]! = 0 then
       let (us, n, bis, ty) ← getHeader args[2:6]
-      let val ← getDeclVal args[6]!
-      pure $ Command.decl dk mods n us bis ty val
+      pure $ .decl dk mods n us bis ty (← getDeclVal args[6]!) (← opt getUWF args[7]!)
     else
       let (us, bis) ← getMutualHeader args[2:5]
-      pure $ Command.mutualDecl dk mods us bis (← arr (getMutual getArm) args[5]!)
+      pure $ .mutualDecl dk mods us bis (← arr (getMutual getArm) args[5]!) (← opt getUWF args[6]!)
 
   getNotationCmd (mk : Option MixfixKind) (args : Array AstId) : M Command :=
     return Command.notation


### PR DESCRIPTION
This is blocked on leanprover-community/lean#784 making its way through the pipeline.

The output, while syntactically correct, is pretty rough:
```lean
theorem WellFounded.asymmetric {α : Sort _} {r : α → α → Prop} (h : WellFounded r) : ∀ ⦃a b⦄, r a b → ¬r b a
  | a => fun b hab hba => WellFounded.asymmetric hba hab termination_by' ⟨_, h⟩decreasing_by assumption
```
This will need to be fixed in core though. `where` clause formatting is also broken in a similar way:
```lean
/-- The characteristic of the product of rings is the least common multiple of the
characteristics of the two rings. -/
instance [CharP S q] :
    CharP (R × S)
      (Nat.lcm p
        q) where cast_eq_zero_iff := by
    simp [Prod.ext_iff, CharP.cast_eq_zero_iff R p, CharP.cast_eq_zero_iff S q, Nat.lcm_dvd_iff]
```