### PR TITLE
feat: generate #align commands for alias

### DIFF
--- a/Mathport/Syntax/Translate/Tactic/Mathlib/Alias.lean
+++ b/Mathport/Syntax/Translate/Tactic/Mathlib/Alias.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import Mathport.Syntax.Translate.Tactic.Basic
+import Mathport.Syntax.Translate.Command
 
 open Lean
 
@@ -21,8 +22,13 @@ open AST3 Parser
     let doc := doc.map trDocComment
     let old ← mkIdentI old
     match args with
-    | Sum.inl ns => `(command| $[$doc]? alias $old ← $(← liftM $ ns.mapM mkIdentI)*)
-    | Sum.inr none => `(command| $[$doc]? alias $old ↔ ..)
+    | Sum.inl ns =>
+      ns.forM (do _ ← trDeclId · none)
+      `(command| $[$doc]? alias $old ← $(← liftM $ ns.mapM mkIdentI)*)
+    | Sum.inr none =>
+      warn! "warning: don't know how to generate #align statements for .."
+      `(command| $[$doc]? alias $old ↔ ..)
     | Sum.inr (some (l, r)) => do
+      if let .ident li := l then _ ← trDeclId li none
+      if let .ident ri := r then _ ← trDeclId ri none
       `(command| $[$doc]? alias $old ↔ $(← trBinderIdentI l) $(← trBinderIdentI r))
-


### PR DESCRIPTION
I'm sure this is not correct in all edge cases, but hopefully it will only go wrong in obvious ways.
Currently, it's very easy to forget to add #aligns for aliases (and it's also a bit inconvenient to do it manually).