### PR TITLE
fix: adjust cat naming heuristic

### DIFF
--- a/Mathport/Util/String.lean
+++ b/Mathport/Util/String.lean
@@ -13,9 +13,7 @@ def snake2pascalCamel (snake : String) (lc : Bool) : String := Id.run do
   pascal
 
 def snake2pascal (snake : String) : String :=
-  -- pre-empt collisions in category theory where the original is already pascal case
-  if (snake.get 0).isUpper && !snake.contains '_' && !snake.all Char.isUpper then snake ++ "Cat"
-  else snake2pascalCamel snake (lc := false)
+  snake2pascalCamel snake (lc := false)
 
 def snake2camel (snake : String) : String :=
   snake2pascalCamel snake (lc := true)


### PR DESCRIPTION
Lots of types that started with capital letters were getting "Cat" appended even when it made no sense, e.g., Module.End, LinearMap. Here, we only add the Cat suffix when there is already a conflicting name.

Most of the names that get the Cat suffix are actually categories now. False positives:
https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/names.20distinguished.20only.20by.20case