### PR TITLE
fix: simplify field name heuristic

### DIFF
--- a/Mathport/Bridge/Rename.lean
+++ b/Mathport/Bridge/Rename.lean
@@ -107,7 +107,7 @@ def renameField? (n : Name) : Option Name :=
   match n with
   | Name.str Name.anonymous s .. =>
     match getFieldNameMap env |>.find? s with
-    | some (c::_) => Name.mkSimple $ s.convertSnake c.getString!.getCapsKind
+    | some (c::_) => Name.mkSimple c.getString!
     | _ => none
   | _ => none
 


### PR DESCRIPTION
When mathport has to translate a field name (`f` in `x.f`), the correct result must be already in the FieldNameMap, so the old heuristic did not make a lot of sense. Now we at least use a name that exists. This is more of an issue since the introduction of "smart naming" which sometimes generates `names_likeThis`.