### PR TITLE
Harden git checkout calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ mathbin-source:
 	if [ ! -d "sources/mathlib/.git" ]; then \
 		cd sources && git clone https://github.com/leanprover-community/mathlib.git; \
 	fi
-	cd sources/mathlib && git clean -xfd && git fetch && git checkout $(MATHBIN_COMMIT) --
+	cd sources/mathlib && git clean -xfd && git fetch && git checkout "$(MATHBIN_COMMIT)" --
 	cd sources/mathlib && echo -n 'mathlib commit: ' && git rev-parse HEAD
 	cd sources/mathlib && leanpkg configure && ./scripts/mk_all.sh
 
@@ -58,7 +58,7 @@ lean3-source: mathbin-source
 	if [ ! -d "sources/lean/.git" ]; then \
 		cd sources && git clone https://github.com/leanprover-community/lean.git; \
 	fi
-	cd sources/lean && git clean -xfd && git checkout `cd ../mathlib && lean --version | sed -e "s/.*commit \([0-9a-f]*\).*/\1/"` --
+	cd sources/lean && git clean -xfd && git checkout "`cd ../mathlib && lean --version | sed -e "s/.*commit \([0-9a-f]*\).*/\1/"`" --
 	mkdir -p sources/lean/build/release
 	# Run cmake, to create `version.lean` from `version.lean.in`.
 	cd sources/lean/build/release && cmake ../../src

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ mathbin-source:
 	if [ ! -d "sources/mathlib/.git" ]; then \
 		cd sources && git clone https://github.com/leanprover-community/mathlib.git; \
 	fi
-	cd sources/mathlib && git clean -xfd && git fetch && git checkout $(MATHBIN_COMMIT)
+	cd sources/mathlib && git clean -xfd && git fetch && git checkout $(MATHBIN_COMMIT) --
 	cd sources/mathlib && echo -n 'mathlib commit: ' && git rev-parse HEAD
 	cd sources/mathlib && leanpkg configure && ./scripts/mk_all.sh
 
@@ -58,7 +58,7 @@ lean3-source: mathbin-source
 	if [ ! -d "sources/lean/.git" ]; then \
 		cd sources && git clone https://github.com/leanprover-community/lean.git; \
 	fi
-	cd sources/lean && git clean -xfd && git checkout `cd ../mathlib && lean --version | sed -e "s/.*commit \([0-9a-f]*\).*/\1/"`
+	cd sources/lean && git clean -xfd && git checkout `cd ../mathlib && lean --version | sed -e "s/.*commit \([0-9a-f]*\).*/\1/"` --
 	mkdir -p sources/lean/build/release
 	# Run cmake, to create `version.lean` from `version.lean.in`.
 	cd sources/lean/build/release && cmake ../../src


### PR DESCRIPTION
By putting a `--` after the sha, we ensure that git treats it as a ref and not a filename.