### PR TITLE
feat: add support for `matrix.notation`

### DIFF
--- a/Mathport/Syntax/Translate/Notation.lean
+++ b/Mathport/Syntax/Translate/Notation.lean
@@ -157,7 +157,8 @@ def predefinedNotations : NameMap NotationEntry := [
     ("exprsformat! ", unary id),
     ("exprpformat! ", unary id),
     ("exprfail! ", unary id),
-    ("exprtrace! ", unary id)
+    ("exprtrace! ", unary id),
+    ("expr!![ ", unary id)
   ].foldl (fun m (a, k) => m.insert a ⟨Name.anonymous, NotationDesc.builtin, k, true⟩) ∅
 where
   exist := binder

--- a/Mathport/Syntax/Translate/Tactic/Mathlib/Misc2.lean
+++ b/Mathport/Syntax/Translate/Tactic/Mathlib/Misc2.lean
@@ -353,3 +353,8 @@ def trUniqueDiffWithinAt_Ici_Iic_univ (_ : AST3.Expr) : M Syntax.Tactic := do
 -- # set_theory.game.pgame
 @[tr_ni_tactic pgame.pgame_wf_tac] def trPGameWFTac (_ : AST3.Expr) : M Syntax.Tactic :=
   `(tactic| pgame_wf_tac)
+
+-- # data.matrix.notation
+@[tr_user_nota matrix.notation] def trMatrixNotation : TacM Syntax.Term := do
+  let args ← parse (sepBy (tk ";") (sepBy (tk ",") pExpr) <* tk "]")
+  `(!![$[$(← liftM <| args.mapM (·.mapM trExpr)),*];*])

--- a/Mathport/Syntax/Translate/Tactic/Mathlib/Misc2.lean
+++ b/Mathport/Syntax/Translate/Tactic/Mathlib/Misc2.lean
@@ -356,5 +356,12 @@ def trUniqueDiffWithinAt_Ici_Iic_univ (_ : AST3.Expr) : M Syntax.Tactic := do
 
 -- # data.matrix.notation
 @[tr_user_nota matrix.notation] def trMatrixNotation : TacM Syntax.Term := do
-  let args ← parse (sepBy (tk ";") (sepBy (tk ",") pExpr) <* tk "]")
-  `(!![$[$(← liftM <| args.mapM (·.mapM trExpr)),*];*])
+  let args ← parse (
+      (Sum.inl <$> sepBy (tk ";") (sepBy (tk ",") pExpr) <|>
+       Sum.inr <$> (Sum.inl <$> (tk ";")* <|> Sum.inr <$> (tk ",")*)) <* tk "]")
+  match args with
+  | .inl args => `(!![$[$(← liftM <| args.mapM (·.mapM trExpr)),*];*])
+  | .inr (.inl rxz) => pure ⟨mkNode ``Parser.Term.matrixNotationRx0 #[mkAtom "!![",
+      mkNullNode <| mkArray rxz.size <| mkAtom ";", mkAtom "]"]⟩
+  | .inr (.inr zxc) => pure ⟨mkNode ``Parser.Term.matrixNotation0xC #[mkAtom "!![",
+      mkNullNode <| mkArray zxc.size <| mkAtom ";", mkAtom "]"]⟩

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -4,7 +4,7 @@
  [{"git":
    {"url": "https://github.com/leanprover-community/mathlib4",
     "subDir?": null,
-    "rev": "855a245842f79a5d459bf0271fd8cf0f3bba4091",
+    "rev": "dfbb8aad777b5acef3b31f2c3edcc225fe6eea93",
     "name": "mathlib",
     "inputRev?": "master"}},
   {"git":

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -4,7 +4,7 @@
  [{"git":
    {"url": "https://github.com/leanprover-community/mathlib4",
     "subDir?": null,
-    "rev": "b9a0a30342ca06e9817e22dbe46e75fc7f435500",
+    "rev": "855a245842f79a5d459bf0271fd8cf0f3bba4091",
     "name": "mathlib",
     "inputRev?": "master"}},
   {"git":


### PR DESCRIPTION
* [x] depends on: leanprover-community/mathlib4#3429