### PR TITLE
chore: make sed work with both gnu sed and macos sed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,9 @@ mathbin-source:
 	cd sources/mathlib && echo -n 'mathlib commit: ' && git rev-parse HEAD
 	cd sources/mathlib && leanpkg configure && ./scripts/mk_all.sh
 	cd sources/mathlib/archive && git ls-files \
-		| sed -n '/\.lean/ { s=\.lean$$== ; s=/=».«=g; s=^=import «= ; s=$$=»= ; p }' > all.lean
+		| sed -n '/\.lean/ { s/\.lean$$// ; s/\//».«/g ; s/^/import «/ ; s/$$/»/ ; p ; }' > all.lean
 	cd sources/mathlib/counterexamples && git ls-files \
-		| sed -n '/\.lean/ { s=\.lean$$== ; s=/=».«=g; s=^=import «= ; s=$$=»= ; p }' > all.lean
+		| sed -n '/\.lean/ { s/\.lean$$// ; s/\//».«/g ; s/^/import «/ ; s/$$/»/ ; p ; }' > all.lean
 	echo path ./archive >> sources/mathlib/leanpkg.path
 	echo path ./counterexamples >> sources/mathlib/leanpkg.path
 


### PR DESCRIPTION
Only tested on macos, with both versions.