### PR TITLE
doc: expand readme and makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ mathbin-source:
 		| sed -n '/\.lean/ { s/\.lean$$// ; s/\//».«/g ; s/^/import «/ ; s/$$/»/ ; p ; }' > all.lean
 	echo path ./archive >> sources/mathlib/leanpkg.path
 	echo path ./counterexamples >> sources/mathlib/leanpkg.path
+	cd sources/mathlib && leanproject get-cache
 
 # Clone Lean 3, and some preparatory work:
 # * Obtain the commit from (community edition) Lean 3 which mathlib is using
@@ -64,7 +65,7 @@ lean3-source: mathbin-source
 	if [ ! -d "sources/lean/.git" ]; then \
 		cd sources && git clone --depth 1 https://github.com/leanprover-community/lean.git; \
 	fi
-	cd sources/lean && git clean -xfd && git checkout "`cd ../mathlib && lean --version | sed -e "s/.*commit \([0-9a-f]*\).*/\1/"`" --
+	cd sources/lean && git clean -xfd && git fetch && git checkout "`cd ../mathlib && lean --version | sed -e "s/.*commit \([0-9a-f]*\).*/\1/"`" --
 	cd sources/lean && elan override set `cat ../mathlib/leanpkg.toml | grep lean_version | cut -d '"' -f2`
 	mkdir -p sources/lean/build/release
 	# Run cmake, to create `version.lean` from `version.lean.in`.

--- a/Oneshot/README.md
+++ b/Oneshot/README.md
@@ -11,9 +11,9 @@ This is a template which you can use to quickly play with the translation of sni
 4. Run `lake exe cache get`
 5. Run `make build` (go get some coffee!)
 6. Run `make lean3-source`
-7. Get a mathport release with `./download-release.sh $my_choice`, where $my_choice = `nightly-2022-12-13-04` works, **or just** `./download-release.sh` to get the latest one automatically.
+7. Get a mathport release with `./download-release.sh`. You can also use `./download-release.sh  $my_choice` to specify an explicit version, e.g. $my_choice = `nightly-2022-12-13-04`.
 8. Put Lean 3 code in `Oneshot/lean3-in/main.lean`.
-9. Put extra `#align` in `Oneshot/lean4-in/Oneshot.lean`
+9. Put extra `#align` in `Oneshot/lean4-in/Extra.lean`
 10. Run `make oneshot`
 
 After the first run, you only have to repeat steps 8-10, unless you want to update mathlib (step 7) or mathport itself (`git pull` and then steps 4-10).

--- a/Oneshot/README.md
+++ b/Oneshot/README.md
@@ -7,7 +7,7 @@ This is a template which you can use to quickly play with the translation of sni
    git clone https://github.com/leanprover-community/mathport/
    ```
 2. get in the folder: `cd mathport`
-3. install dependencies `cmake`, `gmp`, `gmp-devel`, `jq` if needed (debian/ubuntu `sudo apt install cmake gmp gmp-devel jq`, mac `brew install cmake jq`, etc)
+3. install dependencies `cmake`, `gmp`, `gmp-devel`, `jq` if needed. On debian/ubuntu: `sudo apt install cmake gmp gmp-devel jq` (or `libgmp3-dev` instead of `gmp` and `gmp-devel`). On mac: `brew install cmake jq`. On windows this script might not work.
 4. Run `lake exe cache get`
 5. Run `make build` (go get some coffee!)
 6. Run `make lean3-source`

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Install dependencies if needed:
 - debian/ubuntu: `sudo apt install cmake jq gmp gmp-devel`
   (possibly `libgmp3-dev` instead of `gmp` and `gmp-devel`?)
 - mac: `brew install cmake jq`
+- On windows this script might not work
 
 In the mathport folder:
 


### PR DESCRIPTION
* Clarify that this repo might not work on Windows
* reformulate some of the Oneshot README
* add `leanproject get-cache` in the `mathbin-source` command
* Add `git fetch` in the `lean3-source` command.
  - This last item conflicts with #232 (note that for mathlib we also do an unrestricted `git fetch`)