### PR TITLE
feat: add `shell.nix` file

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,5 @@
+{ pkgs ? import <nixpkgs> {} }:
+  pkgs.mkShell {
+    # nativeBuildInputs is usually what you want -- tools you need to run
+    nativeBuildInputs = with pkgs.buildPackages; [ gcc jq cmake gmpxx ];
+}


### PR DESCRIPTION
This way one can run `nix-shell` in the root folder and get a shell
with all needed dependencies.

--
For a reason I fail to understand, `make build` inside `nix-shell` fails.