### PR TITLE
use #align_import instead of the header comment

### DIFF
--- a/Mathport/Syntax/Translate.lean
+++ b/Mathport/Syntax/Translate.lean
@@ -62,9 +62,9 @@ def AST3toData4 (path : Path) : AST3 → M Data4
     -- todo: use the pretty-printer?
     if let some ci := commitInfo then
       let commit := ci.fileRevs.findD (path.mod3.toFilePath.toString ++ ".lean") ci.commit
-      printOutput f!"#align_import {path.mod3} from {repr ci.repo}@{repr commit}"
+      printOutput f!"#align_import {path.mod3} from {repr ci.repo}@{repr commit}\n\n"
     else
-      printOutput f!"#align_import {path.mod3}"
+      printOutput f!"#align_import {path.mod3}\n\n"
     commands.forM fun c => do
       try trCommand c
       catch e =>

--- a/Mathport/Syntax/Translate.lean
+++ b/Mathport/Syntax/Translate.lean
@@ -57,16 +57,14 @@ def AST3toData4 (path : Path) : AST3 → M Data4
     let fmt ← liftCoreM $ PrettyPrinter.format Parser.Module.header.formatter $
       mkNode ``Parser.Module.header #[mkOptionalNode prel, mkNullNode imp]
     let commitInfo := (← read).config.commitInfo
-    let msg : String :=
-      "! This file was ported from Lean 3 source module " ++ path.mod3.toString ++ "\n" ++
-      (if let some ci := commitInfo
-        then
-        "! " ++ ci.repo ++ " commit " ++ ci.fileRevs.findD (path.mod3.toFilePath.toString ++ ".lean") ci.commit ++ "\n" ++
-        "! Please do not edit these lines, except to modify the commit id\n" ++
-        "! if you have ported upstream changes.\n"
-        else "")
-    printFirstLineComments (some msg)
+    printFirstLineComments
     printOutput fmt
+    -- todo: use the pretty-printer?
+    if let some ci := commitInfo then
+      let commit := ci.fileRevs.findD (path.mod3.toFilePath.toString ++ ".lean") ci.commit
+      printOutput f!"#align_import {path.mod3} from {repr ci.repo}@{repr commit}"
+    else
+      printOutput f!"#align_import {path.mod3}"
     commands.forM fun c => do
       try trCommand c
       catch e =>

--- a/Mathport/Syntax/Translate/Basic.lean
+++ b/Mathport/Syntax/Translate/Basic.lean
@@ -419,13 +419,10 @@ partial def insertComments (stx : Syntax) : M Syntax := do
     | Syntax.node .. => pure <| stx.setArgs (← stx.getArgs.mapM insertComments)
     | _ => pure stx
 
-partial def printFirstLineComments (extraComments : Option String) : M Unit := do
+partial def printFirstLineComments : M Unit := do
   if let some comment ← nextCommentIf (·.start.line ≤ 1) then
-    let comment := match extraComments with
-    | some extra => { comment with text := comment.text ++ "\n" ++ extra }
-    | none => comment
     printOutput (mkCommentString comment)
-    printFirstLineComments none
+    printFirstLineComments
 
 def printRemainingComments : M Unit := do
   for comment in (← get).remainingComments do


### PR DESCRIPTION
Mathport still doesn't actually use the `align_import` information, but it does now _generate_ it.