### PR TITLE
Change the replacement style used for mathlib3port to `keep`

### DIFF
--- a/config.json
+++ b/config.json
@@ -69,7 +69,7 @@
     "sorries": [],
     "skipProofs": false,
     "skipDefEq": true,
-    "replacementStyle": "comment",
+    "replacementStyle": "keep",
     "redundantAlign": true,
     "error2warning" : true,
     "dubiousMsg": false,


### PR DESCRIPTION
These `#print`s and surrounding comments are annoying to remove when re-porting files, and having the declarations commented out isn't particularly useful anyway.

The real motivation here is to make mathport produce a tree that is suitable for inserting between the mathlib3 and mathlib4 history, with ideally-minimal diffs